### PR TITLE
Fix date-dependent test failures by freezing time in a test preload

### DIFF
--- a/apps/frontend/bunfig.toml
+++ b/apps/frontend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/tests/setup.ts"]

--- a/apps/frontend/src/components/timeline/buildGraphData.test.ts
+++ b/apps/frontend/src/components/timeline/buildGraphData.test.ts
@@ -1,7 +1,7 @@
 import type { TimelineEntry } from "$interfaces/timelineEntry";
 
 import { timelineEntries } from "$data/metadata";
-import { describe, it, expect, setSystemTime } from "bun:test";
+import { describe, it, expect } from "bun:test";
 
 import { buildGraphData } from "./buildGraphData";
 import { PX_PER_MONTH } from "./constants";
@@ -13,19 +13,11 @@ const snapshottable = (data: ReturnType<typeof buildGraphData>) => {
 };
 
 describe("buildGraphData snapshot", () => {
-  it("matches desktop snapshot", async () => {
-    // Pin the date so row/pixel calculations are stable across months.
-    // Dynamic imports ensure modules load AFTER the mock is active.
-    setSystemTime(new Date("2026-04-01T00:00:00Z"));
-
-    const { buildGraphData: build } = await import("./buildGraphData");
-    const { timelineEntries: entries } = await import("$data/metadata");
-    const { PX_PER_MONTH: pxPerMonth } = await import("./constants");
-
-    const result = build(entries, pxPerMonth);
+  it("matches desktop snapshot", () => {
+    // Time is pinned in src/tests/setup.ts (preloaded before any module),
+    // so date-derived constants and this snapshot are stable across months.
+    const result = buildGraphData(timelineEntries, PX_PER_MONTH);
     expect(snapshottable(result)).toMatchSnapshot();
-
-    setSystemTime();
   });
 });
 

--- a/apps/frontend/src/tests/setup.ts
+++ b/apps/frontend/src/tests/setup.ts
@@ -1,0 +1,7 @@
+import { setSystemTime } from "bun:test";
+
+// Freeze time before any module loads so date-derived constants (e.g. the
+// timeline's CURRENT_YEAR/CURRENT_MONTH, computed at import time) and their
+// snapshots stay stable as real time moves on.
+// Bump this date together with any affected snapshots.
+setSystemTime(new Date("2026-04-01T00:00:00Z"));


### PR DESCRIPTION
## Problem

CI's test job is currently red on `main`: the `buildGraphData` snapshot test and an `entryEndAbsMonth` test fail because they depend on the real date.

The snapshot test pinned the clock with `setSystemTime(2026-04-01)`, but the file's **static imports had already loaded `constants.ts`** — which captures `CURRENT_YEAR`/`CURRENT_MONTH` at import time — before the pin took effect. The dynamic imports inside the test only returned the cached modules, so the snapshot silently tracked the real date and broke once the month rolled over.

Worse, when the snapshot assertion threw, the trailing `setSystemTime()` reset never ran, so the frozen clock leaked into `types.test.ts` (test files share a process) and failed a second, otherwise-correct test.

## Fix

Freeze time in a `bunfig.toml` test preload (`src/tests/setup.ts`), which runs **before any module loads**. All date-derived constants and snapshots are now stable regardless of when tests run, and the per-test `setSystemTime` ceremony is gone.

The pinned date matches the existing snapshot (2026-04-01), so no snapshots needed regenerating.

## Note

Merging this first unblocks CI for the follow-up SEO / SVG / navigation PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)