### PR TITLE
SEO: absolute OG images, sitemap namespace, path-based pagination, richer meta

### DIFF
--- a/apps/frontend/src/components/blog/BlogPostList.svelte
+++ b/apps/frontend/src/components/blog/BlogPostList.svelte
@@ -18,15 +18,17 @@
   const box = "inline-flex items-center justify-center size-8";
 
   const pageHref = (page: number): string =>
-    page === 1 ? baseHref : `${baseHref}?page=${page}`;
+    page === 1 ? baseHref : `${baseHref}/page/${page}`;
 </script>
 
 {#snippet blogPostCard(post: BlogPostMeta, last: boolean)}
   <li>
     <article class="flex flex-col gap-2">
-      <a href="/blog/{post.slug}" data-sveltekit-preload-data="tap" class="text-2xl font-bold text-surface-100 hover:text-green-500 transition-colors w-fit">
-        {post.title}
-      </a>
+      <h2 class="text-2xl w-fit">
+        <a href="/blog/{post.slug}" data-sveltekit-preload-data="tap" class="text-surface-100 hover:text-green-500 transition-colors">
+          {post.title}
+        </a>
+      </h2>
       <PostDate date={post.date} readingTime={post.readingTime} />
       <p class="text-surface-300 leading-relaxed text-base md:text-lg max-w-3xl">
         {post.description}

--- a/apps/frontend/src/lib/blog.ts
+++ b/apps/frontend/src/lib/blog.ts
@@ -60,15 +60,14 @@ export const slugifyTag = (tag: string): string =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
 
-export const paginatePosts = (posts: BlogPostMeta[], url: URL) => {
+export const paginatePosts = (posts: BlogPostMeta[], currentPage: number) => {
   const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
-  let rawPage: string | null = null;
-  try {
-    rawPage = url.searchParams.get("page");
-  } catch {
-    rawPage = null;
-  }
-  const currentPage = rawPage ? Math.max(1, Math.min(Number(rawPage), totalPages)) : 1;
   const pagedPosts = posts.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
   return { pagedPosts, currentPage, totalPages };
+};
+
+/** Parses a `page` route param. Returns undefined for anything but a positive integer. */
+export const parsePageParam = (raw: string): number | undefined => {
+  if (!/^[1-9]\d*$/.test(raw)) return undefined;
+  return Number(raw);
 };

--- a/apps/frontend/src/lib/config.ts
+++ b/apps/frontend/src/lib/config.ts
@@ -1,6 +1,11 @@
 // @ts-expect-error — Vite enhanced:img query string not resolvable by TypeScript
 import FallbackHeroImage from "$lib/assets/hero_banner.svg?w=1200&h=675&format=webp&url";
 
-export const FALLBACK_HERO_IMAGE = FallbackHeroImage;
-
 export const SITE_URL = "https://viktor.andersson.tech";
+
+// Social scrapers (Open Graph, Twitter Cards) and Google's structured-data
+// parser require absolute image URLs, so prefix the Vite asset path.
+export const FALLBACK_HERO_IMAGE = `${SITE_URL}${FallbackHeroImage}`;
+
+export const FALLBACK_HERO_IMAGE_WIDTH = 1200;
+export const FALLBACK_HERO_IMAGE_HEIGHT = 675;

--- a/apps/frontend/src/lib/helpers/paginationURLs.ts
+++ b/apps/frontend/src/lib/helpers/paginationURLs.ts
@@ -4,18 +4,18 @@ interface PaginationURLs {
   nextURL: string | undefined;
 }
 
+// Pagination uses path segments (/page/2) rather than query strings, because
+// the site is fully prerendered and query strings are ignored for static pages.
+const pageURL = (baseURL: string, page: number): string =>
+  page === 1 ? baseURL : `${baseURL}/page/${page}`;
+
 export const buildPaginationURLs = (
   baseURL: string,
   currentPage: number,
   totalPages: number,
 ): PaginationURLs => {
-  const canonicalURL = currentPage === 1 ? baseURL : `${baseURL}?page=${currentPage}`;
-  const prevURL =
-    currentPage > 1
-      ? currentPage === 2
-        ? baseURL
-        : `${baseURL}?page=${currentPage - 1}`
-      : undefined;
-  const nextURL = currentPage < totalPages ? `${baseURL}?page=${currentPage + 1}` : undefined;
+  const canonicalURL = pageURL(baseURL, currentPage);
+  const prevURL = currentPage > 1 ? pageURL(baseURL, currentPage - 1) : undefined;
+  const nextURL = currentPage < totalPages ? pageURL(baseURL, currentPage + 1) : undefined;
   return { canonicalURL, prevURL, nextURL };
 };

--- a/apps/frontend/src/lib/seo/components/SEO.svelte
+++ b/apps/frontend/src/lib/seo/components/SEO.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { FALLBACK_HERO_IMAGE } from "$lib/config";
+  import {
+    FALLBACK_HERO_IMAGE,
+    FALLBACK_HERO_IMAGE_HEIGHT,
+    FALLBACK_HERO_IMAGE_WIDTH,
+  } from "$lib/config";
   import type { StructuredDataSchema } from "..";
   import { toJsonLd } from "..";
 
@@ -12,7 +16,13 @@
     structuredData,
     noIndex = false,
     image = FALLBACK_HERO_IMAGE,
+    imageWidth = FALLBACK_HERO_IMAGE_WIDTH,
+    imageHeight = FALLBACK_HERO_IMAGE_HEIGHT,
+    imageAlt = "viktor.andersson.tech",
     type = "website",
+    publishedTime,
+    modifiedTime,
+    tags,
   }: {
     title: string;
     description: string;
@@ -22,7 +32,16 @@
     structuredData?: StructuredDataSchema | StructuredDataSchema[];
     noIndex?: boolean;
     image?: string;
+    imageWidth?: number;
+    imageHeight?: number;
+    imageAlt?: string;
     type?: "website" | "article" | "profile" | string;
+    /** ISO 8601 date; emitted as article:published_time when type is "article" */
+    publishedTime?: string;
+    /** ISO 8601 date; emitted as article:modified_time when type is "article" */
+    modifiedTime?: string;
+    /** Emitted as article:tag when type is "article" */
+    tags?: string[];
   } = $props();
 </script>
 
@@ -42,14 +61,27 @@
   {/if}
 
   <meta property="og:site_name" content="Viktor Andersson" />
+  <meta property="og:locale" content="en_US" />
   <meta property="og:type" content={type} />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
 
+  {#if type === "article"}
+    {#if publishedTime}<meta property="article:published_time" content={publishedTime} />{/if}
+    {#if modifiedTime}<meta property="article:modified_time" content={modifiedTime} />{/if}
+    {#each tags ?? [] as tag}
+      <meta property="article:tag" content={tag} />
+    {/each}
+  {/if}
+
   {#if image}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content={image} />
+    <meta name="twitter:image:alt" content={imageAlt} />
     <meta property="og:image" content={image} />
+    <meta property="og:image:width" content={String(imageWidth)} />
+    <meta property="og:image:height" content={String(imageHeight)} />
+    <meta property="og:image:alt" content={imageAlt} />
   {:else}
     <meta name="twitter:card" content="summary" />
   {/if}

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -22,7 +22,7 @@
 
   <section class="flex flex-col gap-8 w-full">
     <section class="flex flex-col gap-4">
-      <h3>Personal</h3>
+      <h2 class="text-2xl">Personal</h2>
       <p class="text-surface-300">
         I'm a Software Engineer by day and hobby coder and home automator by night.
         I enjoy building things that are useful both on a personal level but also for others, either professionally or as contributions to open source.
@@ -30,7 +30,7 @@
       </p>
     </section>
     <section class="flex flex-col gap-4">
-      <h3>Professional</h3>
+      <h2 class="text-2xl">Professional</h2>
       <p class="text-surface-300">
         I work as a full-stack Software Engineer at Electricity Maps and work on everything from our data ingestion, processing pipelines and optimizing our frontend application (optimizations I do for fun).
         I have a passion for optimization, performance and automating things as much as possible.

--- a/apps/frontend/src/routes/blog/+page.server.ts
+++ b/apps/frontend/src/routes/blog/+page.server.ts
@@ -1,46 +1,5 @@
-import { getAllPosts, paginatePosts, PAGE_SIZE } from "$lib/blog";
-import { SITE_URL } from "$lib/config";
-import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
-import {
-  createBreadcrumbListSchema,
-  createCollectionPageSchema,
-  createItemListSchema,
-} from "$lib/seo";
+import type { PageServerLoad } from "./$types";
 
-import type { PageServerLoadEvent } from "./$types";
+import { loadBlogListing } from "./listing";
 
-export const entries = (): Record<string, string>[] => {
-  const posts = getAllPosts();
-  const totalPages = Math.ceil(posts.length / PAGE_SIZE);
-  const result: Record<string, string>[] = [{}]; // {} = /blog (page 1, no param)
-  for (let p = 2; p <= totalPages; p++) {
-    result.push({ page: String(p) });
-  }
-  return result;
-};
-
-export const load = async ({ url }: PageServerLoadEvent) => {
-  const posts = getAllPosts();
-  const paginated = paginatePosts(posts, url);
-  const allSlugs = posts.map((p) => p.slug);
-
-  const { canonicalURL, prevURL, nextURL } = buildPaginationURLs(
-    `${SITE_URL}/blog`,
-    paginated.currentPage,
-    paginated.totalPages,
-  );
-
-  const description = "Thoughts on software engineering, climate tech, and open source.";
-
-  const structuredData = [
-    createCollectionPageSchema({
-      name: "Blog",
-      description,
-      url: canonicalURL,
-      mainEntity: createItemListSchema(allSlugs.map((slug) => `${SITE_URL}/blog/${slug}`)),
-    }),
-    createBreadcrumbListSchema([{ name: "Home", url: SITE_URL }, { name: "Blog" }]),
-  ];
-
-  return { ...paginated, allSlugs, description, structuredData, canonicalURL, prevURL, nextURL };
-};
+export const load = (() => loadBlogListing(1)) satisfies PageServerLoad;

--- a/apps/frontend/src/routes/blog/[slug]/+error.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+error.svelte
@@ -3,7 +3,14 @@
   import FileQuestionMark from "@lucide/svelte/icons/file-question-mark";
   import StatusPage from "$components/StatusPage.svelte";
   import Highlight from "$components/Highlight.svelte";
+  import SEO from "$lib/seo/components/SEO.svelte";
 </script>
+
+<SEO
+  title={`Blog Post Error ${page.status}`}
+  description={page.error?.message || "Sorry, there was a problem loading this blog post."}
+  noIndex={true}
+/>
 
 <StatusPage
   icon={FileQuestionMark}

--- a/apps/frontend/src/routes/blog/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/[slug]/+page.server.ts
@@ -17,7 +17,11 @@ export const load = async ({ params }: PageServerLoadEvent) => {
   if (index === -1) throw error(404, `Post "${params.slug}" not found`);
 
   const post = posts[index];
-  const postUrl = `${SITE_URL}/blog/${params.slug}`;
+  // Build the canonical from the post's own slug, not params.slug, so a
+  // mixed-case request can never become its own canonical URL.
+  const postUrl = `${SITE_URL}/blog/${post.slug}`;
+  const datePublished = new Date(post.date).toISOString();
+  const dateModified = new Date(post.last_updated || post.date).toISOString();
 
   const prevPost =
     index > 0 ? { slug: posts[index - 1].slug, title: posts[index - 1].title } : undefined;
@@ -37,12 +41,14 @@ export const load = async ({ params }: PageServerLoadEvent) => {
     },
     readingTime: post.readingTime,
     postUrl,
+    datePublished,
+    dateModified,
     structuredData: [
       createArticleSchema({
         headline: post.title,
         description: post.description,
-        datePublished: new Date(post.date).toISOString(),
-        dateModified: new Date(post.last_updated || post.date).toISOString(),
+        datePublished,
+        dateModified,
         author: SITE_OWNER_PERSON_REF,
         publisher: SITE_OWNER_PERSON_REF,
         keywords: post.tags,

--- a/apps/frontend/src/routes/blog/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+page.svelte
@@ -42,13 +42,16 @@
 {/snippet}
 
 <SEO
-  title={data.metadata.title}
+  title={`${data.metadata.title} | Viktor Andersson`}
   description={data.metadata.description}
   type="article"
   canonicalURL={data.postUrl}
   structuredData={data.structuredData}
   prevURL={prevURL}
   nextURL={nextURL}
+  publishedTime={data.datePublished}
+  modifiedTime={data.dateModified}
+  tags={data.metadata.tags}
 />
 
 <article class="w-full max-w-prose mx-auto mt-16 flex flex-1 flex-col gap-8">

--- a/apps/frontend/src/routes/blog/listing.ts
+++ b/apps/frontend/src/routes/blog/listing.ts
@@ -1,0 +1,35 @@
+import { getAllPosts, paginatePosts } from "$lib/blog";
+import { SITE_URL } from "$lib/config";
+import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
+import {
+  createBreadcrumbListSchema,
+  createCollectionPageSchema,
+  createItemListSchema,
+} from "$lib/seo";
+
+/** Shared load logic for /blog and /blog/page/[page]. */
+export const loadBlogListing = (page: number) => {
+  const posts = getAllPosts();
+  const paginated = paginatePosts(posts, page);
+  const allSlugs = posts.map((p) => p.slug);
+
+  const { canonicalURL, prevURL, nextURL } = buildPaginationURLs(
+    `${SITE_URL}/blog`,
+    paginated.currentPage,
+    paginated.totalPages,
+  );
+
+  const description = "Thoughts on software engineering, climate tech, and open source.";
+
+  const structuredData = [
+    createCollectionPageSchema({
+      name: "Blog",
+      description,
+      url: canonicalURL,
+      mainEntity: createItemListSchema(allSlugs.map((slug) => `${SITE_URL}/blog/${slug}`)),
+    }),
+    createBreadcrumbListSchema([{ name: "Home", url: SITE_URL }, { name: "Blog" }]),
+  ];
+
+  return { ...paginated, allSlugs, description, structuredData, canonicalURL, prevURL, nextURL };
+};

--- a/apps/frontend/src/routes/blog/page/[page]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/page/[page]/+page.server.ts
@@ -1,0 +1,26 @@
+import { getAllPosts, PAGE_SIZE, parsePageParam } from "$lib/blog";
+import { error, redirect } from "@sveltejs/kit";
+
+import type { PageServerLoadEvent } from "./$types";
+
+import { loadBlogListing } from "../../listing";
+
+export const entries = () => {
+  const totalPages = Math.ceil(getAllPosts().length / PAGE_SIZE);
+  const result: { page: string }[] = [];
+  for (let p = 2; p <= totalPages; p++) {
+    result.push({ page: String(p) });
+  }
+  return result;
+};
+
+export const load = async ({ params }: PageServerLoadEvent) => {
+  const page = parsePageParam(params.page);
+  if (!page) error(404, "Page not found");
+  if (page === 1) redirect(308, "/blog");
+
+  const data = loadBlogListing(page);
+  if (page > data.totalPages) error(404, "Page not found");
+
+  return data;
+};

--- a/apps/frontend/src/routes/blog/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/page/[page]/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import SEO from "$lib/seo/components/SEO.svelte";
+  import BlogPostList from "$components/blog/BlogPostList.svelte";
+  import TitleText from "$components/TitleText.svelte";
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<SEO
+  title={`Viktor Andersson | Blog — Page ${data.currentPage}`}
+  description={data.description}
+  canonicalURL={data.canonicalURL}
+  prevURL={data.prevURL}
+  nextURL={data.nextURL}
+  structuredData={data.structuredData}
+/>
+
+<div class="page-container">
+
+  <TitleText path="blog" subtitle={data.description} />
+
+  <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} />
+</div>

--- a/apps/frontend/src/routes/blog/tag/[tag]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/+page.server.ts
@@ -1,15 +1,8 @@
-import { getAllPosts, getAllTags, slugifyTag, paginatePosts } from "$lib/blog";
-import { SITE_URL } from "$lib/config";
-import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
-import {
-  createBreadcrumbListSchema,
-  createCollectionPageRefSchema,
-  createCollectionPageSchema,
-  createDefinedTermSchema,
-  createItemListSchema,
-} from "$lib/seo";
+import { getAllPosts, getAllTags, slugifyTag } from "$lib/blog";
 
 import type { PageServerLoadEvent } from "./$types";
+
+import { loadTagListing } from "./listing";
 
 export const entries = () => {
   const posts = getAllPosts();
@@ -17,55 +10,4 @@ export const entries = () => {
   return tags.map((tag) => ({ tag: slugifyTag(tag) }));
 };
 
-export const load = async ({ params, url }: PageServerLoadEvent) => {
-  const posts = getAllPosts();
-  const tagSlug = params.tag.toLowerCase();
-
-  const filtered = posts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug));
-
-  // Derive display name from the first matching post's original tag (newest post wins)
-  const displayTag =
-    posts.flatMap((p) => p.tags ?? []).find((t) => slugifyTag(t) === tagSlug) ?? tagSlug;
-
-  const paginated = paginatePosts(filtered, url);
-  const allSlugs = filtered.map((p) => p.slug);
-  const totalPosts = allSlugs.length;
-
-  const baseURL = `${SITE_URL}/blog/tag/${tagSlug}`;
-  const { canonicalURL, prevURL, nextURL } = buildPaginationURLs(
-    baseURL,
-    paginated.currentPage,
-    paginated.totalPages,
-  );
-
-  const description = `Browse ${totalPosts} blog ${totalPosts === 1 ? "post" : "posts"} tagged with "${displayTag}".`;
-
-  const structuredData = [
-    createCollectionPageSchema({
-      name: `Posts tagged "${displayTag}"`,
-      description,
-      url: canonicalURL,
-      mainEntity: createItemListSchema(allSlugs.map((slug) => `${SITE_URL}/blog/${slug}`)),
-      isPartOf: createCollectionPageRefSchema(`${SITE_URL}/blog`),
-      about: createDefinedTermSchema({ name: displayTag }),
-    }),
-    createBreadcrumbListSchema([
-      { name: "Home", url: SITE_URL },
-      { name: "Blog", url: `${SITE_URL}/blog` },
-      { name: `#${displayTag}` },
-    ]),
-  ];
-
-  return {
-    ...paginated,
-    tag: tagSlug,
-    displayTag,
-    allSlugs,
-    totalPosts,
-    description,
-    structuredData,
-    canonicalURL,
-    prevURL,
-    nextURL,
-  };
-};
+export const load = async ({ params }: PageServerLoadEvent) => loadTagListing(params.tag, 1);

--- a/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
@@ -1,0 +1,64 @@
+import { getAllPosts, paginatePosts, slugifyTag } from "$lib/blog";
+import { SITE_URL } from "$lib/config";
+import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
+import {
+  createBreadcrumbListSchema,
+  createCollectionPageRefSchema,
+  createCollectionPageSchema,
+  createDefinedTermSchema,
+  createItemListSchema,
+} from "$lib/seo";
+
+/** Shared load logic for /blog/tag/[tag] and /blog/tag/[tag]/page/[page]. */
+export const loadTagListing = (tag: string, page: number) => {
+  const posts = getAllPosts();
+  const tagSlug = tag.toLowerCase();
+
+  const filtered = posts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug));
+
+  // Derive display name from the first matching post's original tag (newest post wins)
+  const displayTag =
+    posts.flatMap((p) => p.tags ?? []).find((t) => slugifyTag(t) === tagSlug) ?? tagSlug;
+
+  const paginated = paginatePosts(filtered, page);
+  const allSlugs = filtered.map((p) => p.slug);
+  const totalPosts = allSlugs.length;
+
+  const baseURL = `${SITE_URL}/blog/tag/${tagSlug}`;
+  const { canonicalURL, prevURL, nextURL } = buildPaginationURLs(
+    baseURL,
+    paginated.currentPage,
+    paginated.totalPages,
+  );
+
+  const description = `Browse ${totalPosts} blog ${totalPosts === 1 ? "post" : "posts"} tagged with "${displayTag}".`;
+
+  const structuredData = [
+    createCollectionPageSchema({
+      name: `Posts tagged "${displayTag}"`,
+      description,
+      url: canonicalURL,
+      mainEntity: createItemListSchema(allSlugs.map((slug) => `${SITE_URL}/blog/${slug}`)),
+      isPartOf: createCollectionPageRefSchema(`${SITE_URL}/blog`),
+      about: createDefinedTermSchema({ name: displayTag }),
+    }),
+    createBreadcrumbListSchema([
+      { name: "Home", url: SITE_URL },
+      { name: "Blog", url: `${SITE_URL}/blog` },
+      { name: `#${displayTag}` },
+    ]),
+  ];
+
+  return {
+    ...paginated,
+    tag: tagSlug,
+    displayTag,
+    allSlugs,
+    totalPosts,
+    description,
+    structuredData,
+    canonicalURL,
+    prevURL,
+    nextURL,
+  };
+};

--- a/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.server.ts
@@ -1,0 +1,31 @@
+import { getAllPosts, getAllTags, PAGE_SIZE, parsePageParam, slugifyTag } from "$lib/blog";
+import { error, redirect } from "@sveltejs/kit";
+
+import type { PageServerLoadEvent } from "./$types";
+
+import { loadTagListing } from "../../listing";
+
+export const entries = () => {
+  const posts = getAllPosts();
+  const result: { tag: string; page: string }[] = [];
+  for (const tag of getAllTags(posts)) {
+    const tagSlug = slugifyTag(tag);
+    const count = posts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug)).length;
+    const totalPages = Math.ceil(count / PAGE_SIZE);
+    for (let p = 2; p <= totalPages; p++) {
+      result.push({ tag: tagSlug, page: String(p) });
+    }
+  }
+  return result;
+};
+
+export const load = async ({ params }: PageServerLoadEvent) => {
+  const page = parsePageParam(params.page);
+  if (!page) error(404, "Page not found");
+  if (page === 1) redirect(308, `/blog/tag/${params.tag.toLowerCase()}`);
+
+  const data = loadTagListing(params.tag, page);
+  if (page > data.totalPages) error(404, "Page not found");
+
+  return data;
+};

--- a/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import SEO from "$lib/seo/components/SEO.svelte";
+  import BlogPostList from "$components/blog/BlogPostList.svelte";
+  import TitleText from "$components/TitleText.svelte";
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<SEO
+  noIndex={data.totalPosts < 4}
+  title={`Viktor Andersson | #${data.displayTag} — Page ${data.currentPage}`}
+  description={data.description}
+  canonicalURL={data.canonicalURL}
+  prevURL={data.prevURL}
+  nextURL={data.nextURL}
+  structuredData={data.structuredData}
+/>
+
+<div class="page-container">
+
+  <TitleText path="blog/tag/{data.tag}" subtitle="Posts tagged with #{data.displayTag}" />
+
+  <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} baseHref="/blog/tag/{data.tag}" />
+</div>

--- a/apps/frontend/src/routes/sitemap.xml/+server.ts
+++ b/apps/frontend/src/routes/sitemap.xml/+server.ts
@@ -21,7 +21,7 @@ export const _staticPages = [
 
 export const _buildSitemapXml = (pages: SitemapPage[]): string =>
   `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${pages
   .map(
     (page) => `  <url>

--- a/apps/frontend/src/tests/sitemap.xml/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/sitemap.xml/__snapshots__/server.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`sitemap.xml should match snapshot 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://viktor.andersson.tech</loc>
     <lastmod>YYYY-MM-DD</lastmod>

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -41,6 +41,14 @@ const config = {
   kit: {
     adapter: adapter(),
     inlineStyleThreshold: Infinity,
+    prerender: {
+      handleUnseenRoutes: ({ routes, message }) => {
+        // Pagination routes legitimately produce zero pages until the post
+        // count exceeds PAGE_SIZE; fail the build for anything else.
+        const unexpected = routes.filter((id) => !id.endsWith("/page/[page]"));
+        if (unexpected.length > 0) throw new Error(message);
+      },
+    },
     alias: {
       $blogs: "./src/blog_posts",
       $components: "./src/components",


### PR DESCRIPTION
Batch 1 of 3 from an SEO / SVG / navigation review.

## High impact

- **Absolute social share image URLs.** `FALLBACK_HERO_IMAGE` was a root-relative Vite asset path, so `og:image`, `twitter:image` and the JSON-LD Article `image` were relative URLs — which Open Graph/Twitter scrapers and Google's structured-data parser reject. It's now prefixed with `SITE_URL` (matching how `person.ts` already handles the portrait).
- **Sitemap namespace fixed to the spec URI.** `urlset` declared `xmlns="https://www.sitemaps.org/..."`; XML namespaces are compared literally and the spec (and Google's parser) expect `http://`.
- **Path-based pagination.** `?page=` query-string pagination can never work on this site: everything is prerendered and static pages ignore query strings, so `/blog?page=2` would serve page-1 HTML (the old `entries()` returning `{page}` params for a param-less route was a no-op). Not visible today with 2 posts, but it would have silently broken at post #16. Pagination now lives at `/blog/page/[page]` and `/blog/tag/[tag]/page/[page]` with shared `listing.ts` loaders, real `entries()`, 404s for invalid/out-of-range pages, and a 308 from `/page/1` to the canonical base. `handleUnseenRoutes` tolerates these two routes producing zero pages until the post count exceeds `PAGE_SIZE` (SvelteKit otherwise fails the build) while still failing for any other unseen route.

## Smaller fixes

- Blog post canonical is built from `post.slug` instead of raw `params.slug`, so a mixed-case request can't become its own canonical.
- Blog post `<title>` gets the `| Viktor Andersson` brand suffix used everywhere else.
- `SEO.svelte` now emits `og:locale`, `og:image:width/height/alt`, `twitter:image:alt`, and `article:published_time` / `article:modified_time` / `article:tag` for articles (previously only in JSON-LD, invisible to non-Google platforms).
- The blog post error boundary now renders a `<title>` and `noindex` robots meta (it previously had no head tags at all).
- Blog list post titles are real `<h2>` headings (visual size preserved); about-page sections go h1→h2 instead of h1→h3.

## Verification

- `bun run build` passes; checked the prerendered HTML for absolute `og:image`, `og:locale`, `article:*` meta, canonical, and `<h2>`s, and the built `sitemap.xml` for the corrected namespace.
- `svelte-check`, oxlint, oxfmt clean; sitemap/SEO/helper tests pass with the snapshot updated.
- The two timeline test failures visible in CI are pre-existing date-drift failures on `main`, fixed separately in #581 — merge that first and re-run checks here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)