### PR TITLE
Navigation: aria-current, overflow fixes, mobile menu dismissal, skip link

### DIFF
--- a/apps/frontend/src/components/StatusPage.svelte
+++ b/apps/frontend/src/components/StatusPage.svelte
@@ -7,13 +7,13 @@
     title,
     description,
     buttonContent,
-    onAction,
+    href,
   }: {
     icon: LucideIcon;
     title: string;
     description: string;
     buttonContent: Snippet;
-    onAction: () => void;
+    href: string;
   } = $props();
 </script>
 
@@ -33,10 +33,10 @@
     </p>
   </div>
 
-  <button
-    onclick={onAction}
-    class="cursor-pointer rounded-full font-mono backdrop-blur-sm bg-surface-800/80 px-6 py-3 text-sm text-surface-50 transition-colors hover:bg-surface-700/80"
+  <a
+    {href}
+    class="rounded-full font-mono backdrop-blur-sm bg-surface-800/80 px-6 py-3 text-sm text-surface-50 transition-colors hover:bg-surface-700/80 [text-decoration:none]!"
   >
     {@render buttonContent()}
-  </button>
+  </a>
 </div>

--- a/apps/frontend/src/routes/+error.svelte
+++ b/apps/frontend/src/routes/+error.svelte
@@ -16,7 +16,7 @@
   icon={TriangleAlert}
   title={`Error ${page.status}`}
   description={page.error?.message || "Something went wrong. Please try again later."}
-  onAction={() => (window.location.href = "/")}
+  href="/"
 >
   {#snippet buttonContent()}cd <Highlight>~</Highlight>/{/snippet}
 </StatusPage>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
   ] as const;
 
   let open = $state(false);
+  let mobileMenu = $state<HTMLDetailsElement>();
   const year = $derived(new Date().getFullYear());
 
   let { children }: { children: Snippet } = $props();
@@ -25,7 +26,23 @@
   afterNavigate(() => {
     open = false;
   });
+
+  // The home link only matches exactly; section links also match their subpages
+  // (e.g. /blog/some-post keeps Blog marked active).
+  const isActive = (href: string) =>
+    href === "/"
+      ? page.url.pathname === "/"
+      : page.url.pathname === href || page.url.pathname.startsWith(`${href}/`);
 </script>
+
+<svelte:window
+  onkeydown={(event) => {
+    if (open && event.key === "Escape") open = false;
+  }}
+  onclick={(event) => {
+    if (open && mobileMenu && !mobileMenu.contains(event.target as Node)) open = false;
+  }}
+/>
 
 {#snippet navbarLinks()}
   {#each links as link}
@@ -33,8 +50,9 @@
       href={link.href}
       class="text-lg md:flex-1 md:text-center max-md:py-2 max-md:px-4 rounded-full underline-offset-4 font-medium min-w-20 outline-none"
       aria-label={link.label}
+      aria-current={isActive(link.href) ? "page" : undefined}
     >
-      {#if page.url.pathname === link.href}
+      {#if isActive(link.href)}
         <span class="inline-block">&nbsp;</span>>
       {:else}
         cd
@@ -52,15 +70,24 @@
 </svelte:head>
 
 <!-- #region Header -->
-  <header class="sticky top-0 z-10 w-full m-4">
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 rounded-full backdrop-blur-sm bg-surface-800/80 px-4 py-2 font-mono text-sm"
+  >
+    Skip to content
+  </a>
+  <!-- Padding instead of margin: w-full plus horizontal margins would
+       overflow the viewport on browsers with classic scrollbars -->
+  <header class="sticky top-0 z-10 w-full p-4">
     <!-- Desktop nav -->
     <nav
-      class="hidden md:flex font-mono w-fill max-w-5xl mx-auto justify-evenly items-center gap-8 py-4 px-8 rounded-full backdrop-blur-sm bg-surface-800/80"
+      aria-label="Main"
+      class="hidden md:flex font-mono w-full max-w-5xl mx-auto justify-evenly items-center gap-8 py-4 px-8 rounded-full backdrop-blur-sm bg-surface-800/80"
     >
       {@render navbarLinks()}
     </nav>
     <!-- Mobile nav -->
-    <details class="relative md:hidden" bind:open>
+    <details class="relative md:hidden" bind:open bind:this={mobileMenu}>
       <summary
         aria-label="Navigation menu"
         class="list-none cursor-pointer rounded-full backdrop-blur-sm bg-surface-800/80 p-3 text-surface-50 outline-none w-fit"
@@ -68,6 +95,7 @@
         <Menu size={24} />
       </summary>
       <nav
+        aria-label="Main"
         class="absolute flex flex-col gap-1 justify-start top-full mt-2 z-50 rounded-2xl backdrop-blur-sm bg-surface-800/80 py-4 px-4 font-mono"
       >
         {@render navbarLinks()}
@@ -76,12 +104,12 @@
   </header>
   <!-- #endregion -->
   <!-- #region Main -->
-  <main class="flex-1 flex px-4 md:px-8 lg:px-0 flex-col">
+  <main id="main-content" tabindex="-1" class="flex-1 flex px-4 md:px-8 lg:px-0 flex-col outline-none">
     {@render children()}
   </main>
   <!-- #endregion -->
   <!-- #region Footer -->
-  <footer class="flex flex-col w-screen mt-8 mb-2 justify-center items-center">
+  <footer class="flex flex-col w-full mt-8 mb-2 justify-center items-center">
     <small>{year} &copy; Viktor Andersson </small>
     <small
       >Source code licensed under <a

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -23,7 +23,7 @@
 <div class="page-container">
   <TitleText path="" subtitle="Welcome" />
   <ProfileCard />
-  <nav class="font-mono text-lg flex flex-col w-full leading-tight whitespace-pre">
+  <nav aria-label="Site map" class="font-mono text-lg flex flex-col w-full leading-tight whitespace-pre">
     <span><Highlight>~</Highlight>/</span>
     {@render treeLink("/about", "about", "├── ")}
     {@render treeLink("/history", "history", "├── ")}

--- a/apps/frontend/src/routes/blog/[slug]/+error.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+error.svelte
@@ -9,7 +9,7 @@
   icon={FileQuestionMark}
   title={`Blog Post Error ${page.status}`}
   description={page.error?.message || "Sorry, there was a problem loading this blog post."}
-  onAction={() => (window.location.href = "/blog")}
+  href="/blog"
 >
   {#snippet buttonContent()}cd <Highlight>~</Highlight>/blog{/snippet}
 </StatusPage>


### PR DESCRIPTION
Batch 3 of 3 from an SEO / SVG / navigation review.

## Header nav (`+layout.svelte`)

- **`aria-current="page"` on the active link.** The active page was conveyed only by the visual ` >` vs `cd` prompt swap. Also switched from exact pathname equality to section matching, so `/blog/some-post` and `/blog/tag/x` keep Blog marked active (home stays exact-match).
- **Horizontal overflow fixes.** The header was `w-full m-4` — width 100% *plus* horizontal margins overflows the viewport; the footer's `w-screen` (100vw) similarly ignores the scrollbar gutter. Invisible with macOS overlay scrollbars, but produces a horizontal scrollbar on Windows/Linux. Header now uses padding, footer uses `w-full`.
- Fixed the `w-fill` typo on the desktop nav (not a Tailwind utility; it silently generated no CSS) to `w-full`.
- **Mobile menu dismissal.** The `<details>` menu only closed on navigation; it now also closes on Escape and clicks outside.
- Both nav landmarks are labeled `Main` (only one is in the accessibility tree at a time via responsive `hidden`).

## Error pages

- `StatusPage`'s CTA was a `<button>` calling `window.location.href` — replaced with a real `<a href>`, so it supports middle-click/cmd-click, is followable by crawlers, and uses client-side routing instead of a full reload.

## Misc

- Added a skip-to-content link (visually hidden until focused) targeting `main#main-content`, so keyboard users don't tab through the nav on every page.
- The home page's tree-style nav landmark is labeled `Site map` to distinguish it from the header nav.

## Verification

- `bun run build` passes; verified in the prerendered HTML: `aria-current` present in both navs (2× on `/about`, and 2× on a blog *post* page via prefix matching), skip link + `#main-content` target present, no `w-fill`/`w-screen` remaining.
- `svelte-check`, oxlint, oxfmt clean.
- The two timeline test failures in CI are pre-existing date-drift failures on `main`, fixed in #581 — merge that first and re-run checks here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)