### PR TITLE
Unify design system: accent token, type scale, shared utilities

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -45,3 +45,15 @@
   margin-right: auto;
   width: 100%;
 }
+
+/* Frosted "glass pill" surface shared by the nav, mobile menu, skip link
+   and button-style links. Compose with rounded-* and padding per element. */
+@utility glass-surface {
+  @apply bg-surface-800/80 backdrop-blur-sm;
+}
+
+/* Opt a link out of the global `a:hover { underline }` reset (button-style
+   links). Needs !important to beat the reset's specificity — the reset stays. */
+@utility link-plain {
+  text-decoration: none !important;
+}

--- a/apps/frontend/src/components/ActivityLine.svelte
+++ b/apps/frontend/src/components/ActivityLine.svelte
@@ -11,7 +11,7 @@
   };
 </script>
 
-<span class="text-surface-400"
+<span class="text-surface-300"
   >{verbs[activity.type]}
   {#if activity.private}a private repo{:else}<Link href={activity.url} class="hover:underline underline-offset-4">{activity.repo}</Link>{#if activity.message}: “{activity.message}”{/if}{/if}
   <span class="whitespace-nowrap">({relativeTime(activity.timestamp)})</span></span

--- a/apps/frontend/src/components/ContributionsSummary.svelte
+++ b/apps/frontend/src/components/ContributionsSummary.svelte
@@ -5,8 +5,8 @@
 </script>
 
 {#if hasContributions(contributions)}
-  <hr class="w-full border-surface-500 my-1" />
-  <span class="text-surface-400">Contributions in the past {contributions.days} days:</span>
-  <span class="text-surface-400">{contributions.publicCount} public</span>
-  <span class="text-surface-400">{contributions.privateCount} private</span>
+  <hr class="w-full border-surface-700 my-1" />
+  <span class="text-surface-300">Contributions in the past {contributions.days} days:</span>
+  <span class="text-surface-300">{contributions.publicCount} public</span>
+  <span class="text-surface-300">{contributions.privateCount} private</span>
 {/if}

--- a/apps/frontend/src/components/Highlight.svelte
+++ b/apps/frontend/src/components/Highlight.svelte
@@ -3,4 +3,4 @@
   let { children }: { children: Snippet } = $props();
 </script>
 
-<span class="text-green-500">{@render children()}</span>
+<span class="text-accent">{@render children()}</span>

--- a/apps/frontend/src/components/StatusPage.svelte
+++ b/apps/frontend/src/components/StatusPage.svelte
@@ -35,7 +35,7 @@
 
   <a
     {href}
-    class="rounded-full font-mono backdrop-blur-sm bg-surface-800/80 px-6 py-3 text-sm text-surface-50 transition-colors hover:bg-surface-700/80 [text-decoration:none]!"
+    class="rounded-full font-mono glass-surface px-6 py-3 text-sm text-surface-50 transition-colors hover:bg-surface-700/80 link-plain"
   >
     {@render buttonContent()}
   </a>

--- a/apps/frontend/src/components/TitleText.svelte
+++ b/apps/frontend/src/components/TitleText.svelte
@@ -3,7 +3,7 @@
   let { path, subtitle, prefix = "~/" }: { path: string; subtitle?: string; prefix?: string } = $props();
 </script>
 
-<div class="w-full flex flex-col gap-2 border-b border-surface-800 pb-6">
+<div class="w-full flex flex-col gap-2 border-b border-surface-700 pb-6">
   <h1 class="font-mono break-all" aria-label={path || 'Home'}>
     <Highlight>{prefix[0]}</Highlight>{prefix.slice(1)}{path}
   </h1>

--- a/apps/frontend/src/components/blog/AuthorBanner.svelte
+++ b/apps/frontend/src/components/blog/AuthorBanner.svelte
@@ -3,7 +3,7 @@
   import portrait from "$images/Viktor_Andersson.jpeg?w=40;80&enhanced";
 </script>
 
-<hr class="border-surface-500" />
+<hr class="border-surface-700" />
 <div class="flex items-center gap-3">
   <enhanced:img
     src={portrait}
@@ -11,6 +11,6 @@
     class="rounded-full w-10 h-10 object-cover"
     fetchpriority="high"
   />
-  <a href="/" class="text-base text-surface-100 hover:text-primary-200 transition-colors font-medium">Viktor Andersson</a>
+  <a href="/" class="text-base text-surface-100 hover:text-accent transition-colors font-medium">Viktor Andersson</a>
 </div>
-<hr class="border-surface-500" />
+<hr class="border-surface-700" />

--- a/apps/frontend/src/components/blog/BlogPostList.svelte
+++ b/apps/frontend/src/components/blog/BlogPostList.svelte
@@ -24,13 +24,13 @@
 {#snippet blogPostCard(post: BlogPostMeta, last: boolean)}
   <li>
     <article class="flex flex-col gap-2">
-      <h2 class="text-2xl w-fit">
-        <a href="/blog/{post.slug}" data-sveltekit-preload-data="tap" class="text-surface-100 hover:text-green-500 transition-colors">
+      <h2 class="w-fit">
+        <a href="/blog/{post.slug}" data-sveltekit-preload-data="tap" class="text-surface-100 hover:text-accent transition-colors">
           {post.title}
         </a>
       </h2>
       <PostDate date={post.date} readingTime={post.readingTime} />
-      <p class="text-surface-300 leading-relaxed text-base md:text-lg max-w-3xl">
+      <p class="text-surface-300 leading-relaxed text-base max-w-3xl">
         {post.description}
       </p>
       <PostTags tags={post.tags} />
@@ -43,7 +43,7 @@
 
 {#snippet chevron(href: string | undefined, label: string, Icon: LucideIcon)}
   {#if href}
-    <a {href} class={[box, 'text-surface-300 hover:text-green-500 transition-colors']} aria-label={label}>
+    <a {href} class={[box, 'text-surface-300 hover:text-accent transition-colors']} aria-label={label}>
       <Icon size={16} />
     </a>
   {:else}
@@ -70,9 +70,9 @@
 
           {#each Array.from({ length: totalPages }, (_, i) => i + 1) as page}
             {#if page === currentPage}
-              <span class={[box, 'text-green-500']} aria-current="page">{page}</span>
+              <span class={[box, 'text-accent']} aria-current="page">{page}</span>
             {:else}
-              <a href={pageHref(page)} class={[box, 'text-surface-300 hover:text-green-500 transition-colors']}>{page}</a>
+              <a href={pageHref(page)} class={[box, 'text-surface-300 hover:text-accent transition-colors']}>{page}</a>
             {/if}
           {/each}
 

--- a/apps/frontend/src/components/blog/PostTags.svelte
+++ b/apps/frontend/src/components/blog/PostTags.svelte
@@ -11,8 +11,8 @@
 {#if tags?.length}
   <div class="flex flex-wrap gap-x-4 gap-y-2 text-sm font-mono">
     {#each tags as tag}
-      <a href="/blog/tag/{slugifyTag(tag)}" class="text-surface-300 hover:text-green-500 transition-colors">
-        <span class="text-green-500">#</span>{tag}
+      <a href="/blog/tag/{slugifyTag(tag)}" class="text-surface-300 hover:text-accent transition-colors">
+        <span class="text-accent">#</span>{tag}
       </a>
     {/each}
   </div>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -49,7 +49,7 @@
   {#each links as link}
     <a
       href={link.href}
-      class="text-lg md:flex-1 md:text-center max-md:py-2 max-md:px-4 rounded-full underline-offset-4 font-medium min-w-20 outline-none"
+      class="text-lg md:text-center whitespace-nowrap max-md:py-2 max-md:px-4 rounded-full underline-offset-4 font-medium min-w-20 outline-none"
       aria-label={link.label}
       aria-current={isActive(link.href) ? "page" : undefined}
     >
@@ -73,7 +73,7 @@
 <!-- #region Header -->
   <a
     href="#main-content"
-    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 rounded-full backdrop-blur-sm bg-surface-800/80 px-4 py-2 font-mono text-sm"
+    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 rounded-full glass-surface px-4 py-2 font-mono text-sm"
   >
     Skip to content
   </a>
@@ -83,7 +83,7 @@
     <!-- Desktop nav -->
     <nav
       aria-label="Main"
-      class="hidden md:flex font-mono w-full max-w-5xl mx-auto justify-evenly items-center gap-8 py-4 px-8 rounded-full backdrop-blur-sm bg-surface-800/80"
+      class="hidden md:flex font-mono w-full max-w-4xl mx-auto justify-evenly items-center gap-4 lg:gap-8 py-4 px-4 lg:px-8 rounded-full glass-surface"
     >
       {@render navbarLinks()}
     </nav>
@@ -91,13 +91,13 @@
     <details class="relative md:hidden" bind:open bind:this={mobileMenu}>
       <summary
         aria-label="Navigation menu"
-        class="list-none cursor-pointer rounded-full backdrop-blur-sm bg-surface-800/80 p-3 text-surface-50 outline-none w-fit"
+        class="list-none cursor-pointer rounded-full glass-surface p-3 text-surface-50 outline-none w-fit"
       >
         <Menu size={24} />
       </summary>
       <nav
         aria-label="Main"
-        class="absolute flex flex-col gap-1 justify-start top-full mt-2 z-50 rounded-2xl backdrop-blur-sm bg-surface-800/80 py-4 px-4 font-mono"
+        class="absolute flex flex-col gap-1 justify-start top-full mt-2 z-50 rounded-2xl glass-surface py-4 px-4 font-mono"
       >
         {@render navbarLinks()}
       </nav>

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 </script>
 
 {#snippet treeChar(char: string)}<span class="text-2xl text-surface-500" aria-hidden="true">{char}</span>{/snippet}
-{#snippet treeLink(href: string, label: string, prefix: string)}<a {href} class="flex items-center [text-decoration:none]!">{@render treeChar(prefix)}<span class="hover:underline underline-offset-4">{label}</span></a>{/snippet}
+{#snippet treeLink(href: string, label: string, prefix: string)}<a {href} class="flex items-center link-plain">{@render treeChar(prefix)}<span class="hover:underline underline-offset-4">{label}</span></a>{/snippet}
 
 <SEO
   title="Viktor Andersson - Software Engineer"

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -22,16 +22,16 @@
 
   <section class="flex flex-col gap-8 w-full">
     <section class="flex flex-col gap-4">
-      <h2 class="text-2xl">Personal</h2>
-      <p class="text-surface-300">
+      <h2>Personal</h2>
+      <p class="text-surface-300 text-base">
         I'm a Software Engineer by day and hobby coder and home automator by night.
         I enjoy building things that are useful both on a personal level but also for others, either professionally or as contributions to open source.
         When I'm not coding you can find me watching Sci-Fi and Formula 1, going on walks or just reading a nice Sci-Fi book. Yes I do love Sci-Fi.
       </p>
     </section>
     <section class="flex flex-col gap-4">
-      <h2 class="text-2xl">Professional</h2>
-      <p class="text-surface-300">
+      <h2>Professional</h2>
+      <p class="text-surface-300 text-base">
         I work as a full-stack Software Engineer at Electricity Maps and work on everything from our data ingestion, processing pipelines and optimizing our frontend application (optimizations I do for fun).
         I have a passion for optimization, performance and automating things as much as possible.
         I prefer to do this in a way that is maintainable and lowers our technical debt, processing needs and data usage so it has as low impact on the environment as possible.

--- a/apps/frontend/src/routes/activity/+page.svelte
+++ b/apps/frontend/src/routes/activity/+page.svelte
@@ -21,8 +21,8 @@
 
 <div class="page-container">
   <TitleText path="activity" subtitle={data.description} />
-  <section class="font-mono text-lg flex flex-col gap-4 w-full leading-tight" aria-label="Latest GitHub activity">
-    <span
+  <section class="font-mono text-base flex flex-col gap-4 w-full leading-tight" aria-label="Latest GitHub activity">
+    <span class="text-lg"
       ><Highlight>$</Highlight> gh activity{activity?.log.length ? ` -n ${activity.log.length}` : ""}</span
     >
     <div class="flex flex-col gap-2">

--- a/apps/frontend/src/routes/blog/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+page.svelte
@@ -20,7 +20,7 @@
   <a
     {href}
     class={[
-      'group relative flex items-center md:max-w-1/2 text-surface-300 hover:text-green-500 transition-colors',
+      'group relative flex items-center md:max-w-1/2 text-surface-300 hover:text-accent transition-colors',
       !isPrev && 'text-right md:ml-auto'
     ]}
   >
@@ -31,7 +31,7 @@
     {/if}
     <div class={['flex flex-col', !isPrev && 'items-end']}>
       <span class="text-xs font-mono uppercase tracking-wide">{isPrev ? "Newer" : "Older"}</span>
-      <span class="text-sm text-surface-300 group-hover:text-green-500 transition-colors">{title}</span>
+      <span class="text-sm text-surface-300 group-hover:text-accent transition-colors">{title}</span>
     </div>
     {#if !isPrev}
       <span class="absolute -right-6 top-1/2 -translate-y-1/2">

--- a/apps/frontend/src/routes/blog/[slug]/blog.css
+++ b/apps/frontend/src/routes/blog/[slug]/blog.css
@@ -7,7 +7,7 @@
   :where(ol > li)::marker,
   :where(th),
   :where(th) a {
-    color: var(--color-green-500);
+    color: var(--color-accent);
   }
 }
 

--- a/apps/frontend/src/theme.css
+++ b/apps/frontend/src/theme.css
@@ -78,6 +78,11 @@
   --color-surface-900: #191919;
   --color-surface-950: #111111;
 
+  /* Accent | #22c55e (green) — brand accent for highlights, active nav,
+     content-link hovers, and prose markers. The single source of truth;
+     use `accent` utilities (text-accent, hover:text-accent, …) not green-*. */
+  --color-accent: #22c55e;
+
   /* Font families */
   --font-inter: "Inter", "Inter fallback", sans-serif;
   --font-mono: "Monaspace Neon", "Monaspace Neon fallback", monospace;
@@ -104,19 +109,21 @@ a:hover {
   @apply underline;
 }
 
-/* Heading typography classes */
+/* Heading typography scale — descending ladder, used outside blog prose
+   (the `prose` plugin sets its own sizes inside .blog-content).
+   h1 = page/display title · h2 = section & card heading · h3/h4 = sub-headings. */
 h1 {
   @apply text-surface-100 text-4xl font-bold;
 }
 
 h2 {
-  @apply text-surface-100 text-3xl font-bold;
-}
-
-h3 {
   @apply text-surface-100 text-2xl font-bold;
 }
 
-h4 {
+h3 {
   @apply text-surface-100 text-xl font-bold;
+}
+
+h4 {
+  @apply text-surface-100 text-lg font-bold;
 }


### PR DESCRIPTION
## Summary

A design-consistency pass across the frontend that removes hardcoded values and duplicated markup in favor of a small, documented design system. No new features — purely styling unification. The site's terminal/CLI aesthetic is preserved throughout.

## Changes

**Tokens & scale** (`theme.css`)
- Added `--color-accent` (`#22c55e`) — the accent is now one token. Replaced all 10 hardcoded `green-500` uses plus the lone `hover:text-primary-200` outlier in `AuthorBanner`.
- Retuned the base heading ladder to match real usage: `h2` 3xl→2xl, `h3` 2xl→xl, `h4` xl→lg. Dropped the per-page `text-2xl` overrides on about + blog list (`ProfileCard`, section headings and blog titles now render at one size).

**Shared utilities** (`app.css`)
- `glass-surface` (`bg-surface-800/80 backdrop-blur-sm`) replaces the pill motif that was copy-pasted 5× (nav, mobile menu, skip link, status button).
- `link-plain` replaces the two `[text-decoration:none]!` arbitrary overrides — a named opt-out of the global `a:hover` underline (the reset itself is untouched).

**Standardized values**
- Muted text: secondary body → `surface-300` (the `/activity` log was a shade darker at `surface-400`); icons stay `surface-400`, decorative/empty stay `surface-500`.
- Dividers: all `<hr>`/borders → `surface-700` (were a mix of 500/700/800).

**Text sizes** — collapsed the responsive `text-base md:text-lg` switching into three flat tiers:
- **Lead** `text-lg` — nav links, page subtitle, home sitemap tree, `/activity` `$` command prompt
- **Body** `text-base` — about prose, blog descriptions, `/activity` log output
- **Meta** `text-sm` — dates, tags, timeline card body, profile links

**Nav fix** — the active `/activity` link wrapped to two lines with uneven spacing. Dropped the `flex-1` equal-column layout (which forced narrow columns and lopsided gaps) in favor of content-sized links with `whitespace-nowrap` and even `justify-evenly` spacing; made gap/padding responsive so five links fit at the `md` breakpoint.

## Testing
- `bun run format:check` ✅
- `bun run lint` ✅
- `bun run check:ci` (svelte-check) ✅ — 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)