### PR TITLE
Timeline reactivity cleanup and global navigation loading bar

### DIFF
--- a/apps/frontend/src/components/Timeline.svelte
+++ b/apps/frontend/src/components/Timeline.svelte
@@ -10,60 +10,37 @@
 		GRAPH_TOP_PADDING_PX
 	} from './timeline/constants';
 	import { buildGraphData } from './timeline/buildGraphData';
+	import { MediaQuery, SvelteMap } from 'svelte/reactivity';
+	import type { Attachment } from 'svelte/attachments';
 
 	let { entries }: { entries: TimelineEntry[] } = $props();
 
-	const COMPACT_QUERY = '(max-width: 640px)';
+	// Resolved synchronously on first client read, so mobile avoids hydrating the
+	// desktop layout then reflowing. SSR uses the fallback (false -> desktop).
+	const compact = new MediaQuery('max-width: 640px');
+	const mode = $derived<TimelineMode>(compact.current ? 'compact' : 'desktop');
 
-	// Resolve the mode during init (not in the after-paint effect) so mobile
-	// clients don't hydrate a desktop layout and then reflow to compact.
-	let mode = $state<TimelineMode>(
-		typeof window !== 'undefined' && window.matchMedia(COMPACT_QUERY).matches
-			? 'compact'
-			: 'desktop'
-	);
-
-	$effect(() => {
-		const mql = window.matchMedia(COMPACT_QUERY);
-		const update = () => {
-			mode = mql.matches ? 'compact' : 'desktop';
-		};
-		update();
-		mql.addEventListener('change', update);
-		return () => mql.removeEventListener('change', update);
-	});
-
-	let measuredHeightsByEntry = $state(new Map<TimelineEntry, number>());
+	const measuredHeightsByEntry = new SvelteMap<TimelineEntry, number>();
 
 	const setMeasuredHeight = (entry: TimelineEntry, height: number) => {
 		if (measuredHeightsByEntry.get(entry) === height) return;
-		const next = new Map(measuredHeightsByEntry);
-		next.set(entry, height);
-		measuredHeightsByEntry = next;
+		measuredHeightsByEntry.set(entry, height);
 	};
 
-	const observeCardHeight = (element: HTMLElement, entry: TimelineEntry) => {
-		if (typeof ResizeObserver === 'undefined') return;
+	// Attachment factory: re-runs (tears down + re-observes) whenever the bound
+	// entry changes, replacing the action's manual update() lifecycle.
+	const observeCardHeight =
+		(entry: TimelineEntry): Attachment<HTMLElement> =>
+		(element) => {
+			if (typeof ResizeObserver === 'undefined') return;
 
-		let currentEntry = entry;
-		const measure = () => {
-			setMeasuredHeight(currentEntry, element.offsetHeight);
+			const measure = () => setMeasuredHeight(entry, element.offsetHeight);
+			const observer = new ResizeObserver(measure);
+			observer.observe(element);
+			measure();
+
+			return () => observer.disconnect();
 		};
-
-		const observer = new ResizeObserver(measure);
-		observer.observe(element);
-		measure();
-
-		return {
-			update(nextEntry: TimelineEntry) {
-				currentEntry = nextEntry;
-				measure();
-			},
-			destroy() {
-				observer.disconnect();
-			}
-		};
-	};
 
 	const yearMarkers = $derived.by(() => {
 		const markers: number[] = [];
@@ -102,7 +79,7 @@
 						isLeft ? 'justify-end' : 'justify-start'
 					]}
 					style="grid-row: {node.gridRow} / {node.gridRowEnd};"
-					use:observeCardHeight={node.entry}
+					{@attach observeCardHeight(node.entry)}
 				>
 					<TimelineAccordionCard
 						entry={node.entry}

--- a/apps/frontend/src/components/timeline/TimelineGraph.svelte
+++ b/apps/frontend/src/components/timeline/TimelineGraph.svelte
@@ -7,6 +7,7 @@
     toAbsoluteMonth,
     entryEndAbsMonth,
   } from "./types";
+  import { afterNavigate } from "$app/navigation";
 
   let {
     graphData,
@@ -20,21 +21,13 @@
     totalHeight: number;
   } = $props();
 
+  // Draw in on arrival (afterNavigate fires on mount and on navigations) rather
+  // than on scroll — the graph is tall enough an IntersectionObserver could miss.
   let inView = $state(false);
 
-  const observeInView = (node: HTMLElement) => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          inView = true;
-          observer.unobserve(node);
-        }
-      },
-      { threshold: 0.15 },
-    );
-    observer.observe(node);
-    return { destroy: () => observer.disconnect() };
-  };
+  afterNavigate(() => {
+    inView = true;
+  });
 
   const maxGridRow = $derived(Math.max(...graphData.nodes.map((n) => n.gridRow)));
 
@@ -112,7 +105,6 @@
     inView && 'in-view'
   ]}
   style="grid-row: 1 / {graphData.totalGridRows + 1}; width: {graphData.graphWidth}px;"
-  use:observeInView
 >
   <!-- Decorative: the accordion cards carry all of the graph's information -->
   <svg
@@ -231,7 +223,7 @@
     }
   }
 
-  /* Without JavaScript the IntersectionObserver never adds .in-view;
+  /* Without JavaScript nothing adds .in-view (afterNavigate never runs);
      show the finished graph instead of leaving it hidden. */
   @media (scripting: none) {
     .graph-line {

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -6,9 +6,11 @@
   import "../app.css";
   import Menu from "@lucide/svelte/icons/menu";
   import { afterNavigate } from "$app/navigation";
-  import { page } from "$app/state";
+  import { page, navigating } from "$app/state";
   import Highlight from "$components/Highlight.svelte";
   import { type Snippet } from "svelte";
+  import { cubicOut } from "svelte/easing";
+  import { fade } from "svelte/transition";
 
   const links = [
     { href: "/", label: "Home", name: "" },
@@ -27,6 +29,28 @@
   afterNavigate(() => {
     open = false;
   });
+
+  // Global navigation progress bar. The delay tells a real wait (an SSR route
+  // load) from an instant navigation, so prerendered pages don't flash it.
+  let showProgress = $state(false);
+
+  $effect(() => {
+    if (!navigating.to) {
+      showProgress = false;
+      return;
+    }
+    const timer = setTimeout(() => (showProgress = true), 200);
+    return () => clearTimeout(timer);
+  });
+
+  const reduceMotion = () => window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // Indeterminate creep toward ~90% (no built-in fits a horizontal-only scale).
+  // The `fade` out reverts to the scaleX(1) base, so completion snaps to full.
+  const creep = (_node: Element, { duration = 8000 } = {}) => {
+    if (reduceMotion()) return { duration: 0 };
+    return { duration, easing: cubicOut, css: (t: number) => `transform: scaleX(${0.9 * t})` };
+  };
 
   // The home link only matches exactly; section links also match their subpages
   // (e.g. /blog/some-post keeps Blog marked active).
@@ -69,6 +93,15 @@
   <link rel="icon" href={icon96} type="image/png" sizes="96x96" />
   <link rel="apple-touch-icon" href={appleTouchIcon} />
 </svelte:head>
+
+{#if showProgress}
+  <div
+    class="nav-progress"
+    aria-hidden="true"
+    in:creep
+    out:fade={{ duration: reduceMotion() ? 0 : 300, easing: cubicOut }}
+  ></div>
+{/if}
 
 <!-- #region Header -->
   <a
@@ -120,3 +153,14 @@
     >
   </footer>
   <!-- #endregion -->
+
+<style>
+  .nav-progress {
+    position: fixed;
+    inset: 0 0 auto 0;
+    height: 2px;
+    background: var(--color-accent);
+    transform-origin: left;
+    z-index: 50;
+  }
+</style>


### PR DESCRIPTION
## Summary

Timeline reactivity cleanup and a new global navigation loading bar.

### Timeline
- **`SvelteMap`** for card-height measurements — removes the clone-the-whole-map-and-reassign that ran on every `ResizeObserver` callback.
- **`MediaQuery`** replaces the hand-rolled `matchMedia` + effect for compact/desktop mode (resolved synchronously on first client read, so mobile doesn't hydrate the desktop layout then reflow).
- Graph **draw-in triggers on navigation** (`afterNavigate`) instead of a scroll `IntersectionObserver`, which fired late — or never — on the tall graph.

### Global navigation loading bar
- A thin accent progress bar in the root layout, driven by `navigating`, so any non-prerendered route (`/activity` today, future SSR pages) surfaces its load wait.
- 200 ms delay so instant prerendered navigations don't flash it.
- Creep-in + snap-to-full/fade-out built from Svelte transitions; collapses to instant under `prefers-reduced-motion`.

## Test plan
- `svelte-check` (0 errors/warnings), `oxlint`, `oxfmt`, and `bun run build` all pass.
- 79 unit tests pass.
- Loading bar verified via SSR (client-only element, absent from server HTML) and by throttling the network on a client-side nav to `/activity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
