### PR TITLE
Improve SEO: H1s, canonical, structured data, RSS feed

### DIFF
--- a/apps/frontend/src/components/ProfileCard.svelte
+++ b/apps/frontend/src/components/ProfileCard.svelte
@@ -2,6 +2,8 @@
   // @ts-expect-error — Vite enhanced:img query string not resolvable by svelte-check
   import portrait from "$images/Viktor_Andersson.jpeg?w=96;192&enhanced";
   import Link from "$components/Link.svelte";
+
+  let { as = "h2" }: { as?: "h1" | "h2" } = $props();
 </script>
 
 <div class="flex gap-8 items-center w-full">
@@ -12,8 +14,9 @@
     fetchpriority="high"
   />
   <div class="flex flex-col gap-0.5">
-    <h2>Viktor Andersson</h2>
+    <svelte:element this={as} class="text-2xl">Viktor Andersson</svelte:element>
     <p class="text-base text-surface-300">Software Engineer</p>
+    <p class="text-sm text-surface-400">Malmö, Sweden</p>
     <div class="flex flex-wrap gap-4 text-sm mt-1">
       <Link href="https://www.linkedin.com/in/viktor-va-andersson/" mono>open linkedin</Link>
       <Link href="https://github.com/viktorvav99" mono>open github</Link>

--- a/apps/frontend/src/components/TitleText.svelte
+++ b/apps/frontend/src/components/TitleText.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import Highlight from "$components/Highlight.svelte";
-  let { path, subtitle, prefix = "~/" }: { path: string; subtitle?: string; prefix?: string } = $props();
+  // heading: optional visually-hidden page <h1>.
+  let {
+    path,
+    heading,
+    subtitle,
+    prefix = "~/",
+  }: { path: string; heading?: string; subtitle?: string; prefix?: string } = $props();
 </script>
 
 <div class="w-full flex flex-col gap-2 border-b border-surface-700 pb-6">
-  <h1 class="font-mono break-all" aria-label={path || 'Home'}>
+  {#if heading}
+    <h1 class="sr-only">{heading}</h1>
+  {/if}
+  <div class="font-mono break-all text-4xl font-bold text-surface-100" aria-hidden="true">
     <Highlight>{prefix[0]}</Highlight>{prefix.slice(1)}{path}
-  </h1>
+  </div>
   {#if subtitle}
     <p class="text-surface-300 text-lg">{subtitle}</p>
   {/if}

--- a/apps/frontend/src/lib/config.ts
+++ b/apps/frontend/src/lib/config.ts
@@ -1,5 +1,5 @@
 // @ts-expect-error — Vite enhanced:img query string not resolvable by TypeScript
-import FallbackHeroImage from "$lib/assets/hero_banner.svg?w=1200&h=675&format=webp&url";
+import FallbackHeroImage from "$lib/assets/hero_banner.svg?w=1200&h=675&format=jpg&url";
 
 export const SITE_URL = "https://viktor.andersson.tech";
 

--- a/apps/frontend/src/lib/seo/components/SEO.svelte
+++ b/apps/frontend/src/lib/seo/components/SEO.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import {
     FALLBACK_HERO_IMAGE,
     FALLBACK_HERO_IMAGE_HEIGHT,
     FALLBACK_HERO_IMAGE_WIDTH,
+    SITE_URL,
   } from "$lib/config";
   import type { StructuredDataSchema } from "..";
   import { toJsonLd } from "..";
@@ -43,15 +45,20 @@
     /** Emitted as article:tag when type is "article" */
     tags?: string[];
   } = $props();
+
+  // Default to the current path (no trailing slash); noindex pages get no canonical.
+  const resolvedCanonicalURL = $derived(
+    canonicalURL ?? (noIndex ? undefined : SITE_URL + page.url.pathname.replace(/\/$/, "")),
+  );
 </script>
 
 <svelte:head>
   <title>{title}</title>
   <meta name="description" content={description} />
 
-  {#if canonicalURL}
-    <link rel="canonical" href={canonicalURL} />
-    <meta property="og:url" content={canonicalURL} />
+  {#if resolvedCanonicalURL}
+    <link rel="canonical" href={resolvedCanonicalURL} />
+    <meta property="og:url" content={resolvedCanonicalURL} />
   {/if}
   {#if prevURL}<link rel="prev" href={prevURL} />{/if}
   {#if nextURL}<link rel="next" href={nextURL} />{/if}
@@ -67,11 +74,15 @@
   <meta property="og:description" content={description} />
 
   {#if type === "article"}
+    <meta property="article:author" content={`${SITE_URL}/#person`} />
     {#if publishedTime}<meta property="article:published_time" content={publishedTime} />{/if}
     {#if modifiedTime}<meta property="article:modified_time" content={modifiedTime} />{/if}
     {#each tags ?? [] as tag}
       <meta property="article:tag" content={tag} />
     {/each}
+  {:else if type === "profile"}
+    <meta property="profile:first_name" content="Viktor" />
+    <meta property="profile:last_name" content="Andersson" />
   {/if}
 
   {#if image}
@@ -92,6 +103,9 @@
   {#if noIndex}
     <meta name="robots" content="noindex, nofollow" />
   {:else}
-    <meta name="robots" content="index, follow" />
+    <meta
+      name="robots"
+      content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
+    />
   {/if}
 </svelte:head>

--- a/apps/frontend/src/lib/seo/index.ts
+++ b/apps/frontend/src/lib/seo/index.ts
@@ -187,6 +187,7 @@ export interface ArticleSchema {
   "@type": "Article" | "BlogPosting" | "NewsArticle";
   headline: string;
   description?: string;
+  inLanguage?: string;
   image?: string | string[];
   datePublished: string; // ISO 8601 format (e.g., "2026-03-15T21:07:31+01:00")
   dateModified?: string; // ISO 8601 format
@@ -203,6 +204,7 @@ export const createArticleSchema = (
   options: Omit<ArticleSchema, "@type"> & { "@type"?: "Article" | "BlogPosting" | "NewsArticle" },
 ): ArticleSchema => ({
   "@type": options["@type"] || blogPostingType,
+  inLanguage: "en",
   ...options,
 });
 
@@ -282,6 +284,7 @@ export interface CollectionPageSchema {
   "@type": typeof collectionPageType;
   name: string;
   description?: string;
+  inLanguage?: string;
   url: string;
   mainEntity: ItemListSchema;
   isPartOf?: CollectionPageRefSchema;
@@ -290,7 +293,7 @@ export interface CollectionPageSchema {
 
 export const createCollectionPageSchema = (
   options: Omit<CollectionPageSchema, "@type">,
-): CollectionPageSchema => ({ "@type": collectionPageType, ...options });
+): CollectionPageSchema => ({ "@type": collectionPageType, inLanguage: "en", ...options });
 
 export interface WebSiteSchema {
   "@type": typeof webSiteType;
@@ -298,12 +301,14 @@ export interface WebSiteSchema {
   name: string;
   url: string;
   description?: string;
+  inLanguage?: string;
   author?: PersonSchema | OrganizationSchema;
   publisher?: PersonSchema | OrganizationSchema;
 }
 
 export const createWebSiteSchema = (options: Omit<WebSiteSchema, "@type">): WebSiteSchema => ({
   "@type": webSiteType,
+  inLanguage: "en",
   ...options,
 });
 

--- a/apps/frontend/src/lib/seo/person.ts
+++ b/apps/frontend/src/lib/seo/person.ts
@@ -35,7 +35,7 @@ const hh = createCollegeOrUniversitySchema({
 });
 
 export const PROFILE_DATE_CREATED = new Date("2026-03-20").toISOString();
-export const PROFILE_DATE_MODIFIED = new Date("2026-03-21").toISOString();
+export const PROFILE_DATE_MODIFIED = new Date("2026-07-18").toISOString();
 
 export const siteOwnerPerson = createPersonSchema({
   "@id": `${SITE_URL}/#person`,

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -4,7 +4,6 @@
   import ProfileCard from "$components/ProfileCard.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
   import Highlight from "$components/Highlight.svelte";
-  import { SITE_URL } from "$lib/config";
 
   let { data }: { data: PageData } = $props();
 
@@ -17,12 +16,11 @@
 <SEO
   title="Viktor Andersson - Software Engineer"
   description="Personal website for Viktor Andersson, Software Engineer at Electricity Maps and Digital Design and Innovation graduate"
-  canonicalURL={SITE_URL}
   structuredData={data.structuredData}
 />
 <div class="page-container">
   <TitleText path="" subtitle="Welcome" />
-  <ProfileCard />
+  <ProfileCard as="h1" />
   <nav aria-label="Site map" class="font-mono text-lg flex flex-col w-full leading-tight whitespace-pre">
     <span><Highlight>~</Highlight>/</span>
     {@render treeLink("/about", "about", "├── ")}

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -10,13 +10,13 @@
 
 <SEO
   title="Viktor Andersson | About"
-  description="About Viktor Andersson, Software Engineer at Electricity Maps."
+  description="About Viktor Andersson, Software Engineer based in Malmö, Sweden, working at Electricity Maps."
   canonicalURL={`${SITE_URL}/about`}
   structuredData={data.structuredData}
 />
 
 <div class="page-container">
-  <TitleText path="about" subtitle="Get to know me" />
+  <TitleText path="about" heading="About" subtitle="Get to know me" />
 
   <ProfileCard />
 

--- a/apps/frontend/src/routes/activity/+page.svelte
+++ b/apps/frontend/src/routes/activity/+page.svelte
@@ -20,7 +20,7 @@
 />
 
 <div class="page-container">
-  <TitleText path="activity" subtitle={data.description} />
+  <TitleText path="activity" heading="Activity" subtitle={data.description} />
   <section class="font-mono text-base flex flex-col gap-4 w-full leading-tight" aria-label="Latest GitHub activity">
     <span class="text-lg"
       ><Highlight>$</Highlight> gh activity{activity?.log.length ? ` -n ${activity.log.length}` : ""}</span

--- a/apps/frontend/src/routes/blog/+layout.svelte
+++ b/apps/frontend/src/routes/blog/+layout.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { SITE_URL } from "$lib/config";
+  import type { Snippet } from "svelte";
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+<svelte:head>
+  <link rel="alternate" type="application/rss+xml" title="Viktor Andersson" href={`${SITE_URL}/rss.xml`} />
+</svelte:head>
+
+{@render children()}

--- a/apps/frontend/src/routes/blog/+page.svelte
+++ b/apps/frontend/src/routes/blog/+page.svelte
@@ -18,7 +18,7 @@
 
 <div class="page-container">
 
-  <TitleText path="blog" subtitle={data.description} />
+  <TitleText path="blog" heading="Blog" subtitle={data.description} />
 
   <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} />
 </div>

--- a/apps/frontend/src/routes/blog/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/page/[page]/+page.svelte
@@ -18,7 +18,7 @@
 
 <div class="page-container">
 
-  <TitleText path="blog" subtitle={data.description} />
+  <TitleText path="blog" heading="Blog" subtitle={data.description} />
 
   <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} />
 </div>

--- a/apps/frontend/src/routes/blog/tag/[tag]/+page.svelte
+++ b/apps/frontend/src/routes/blog/tag/[tag]/+page.svelte
@@ -19,7 +19,7 @@
 
 <div class="page-container">
 
-  <TitleText path="blog/tag/{data.tag}" subtitle="Posts tagged with #{data.displayTag}" />
+  <TitleText path="blog/tag/{data.tag}" heading="Posts tagged #{data.displayTag}" subtitle="Posts tagged with #{data.displayTag}" />
 
   <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} baseHref="/blog/tag/{data.tag}" />
 </div>

--- a/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.svelte
@@ -19,7 +19,7 @@
 
 <div class="page-container">
 
-  <TitleText path="blog/tag/{data.tag}" subtitle="Posts tagged with #{data.displayTag}" />
+  <TitleText path="blog/tag/{data.tag}" heading="Posts tagged #{data.displayTag}" subtitle="Posts tagged with #{data.displayTag}" />
 
   <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} baseHref="/blog/tag/{data.tag}" />
 </div>

--- a/apps/frontend/src/routes/history/+page.svelte
+++ b/apps/frontend/src/routes/history/+page.svelte
@@ -18,7 +18,7 @@
 />
 
 <div class="page-container">
-  <TitleText path="history" subtitle={data.description} />
+  <TitleText path="history" heading="History" subtitle={data.description} />
   <section class="flex flex-col gap-4 items-center w-full">
     <Timeline entries={timelineEntries} />
   </section>

--- a/apps/frontend/src/routes/rss.xml/+server.ts
+++ b/apps/frontend/src/routes/rss.xml/+server.ts
@@ -1,0 +1,70 @@
+export const prerender = true;
+import { getAllPosts } from "$lib/blog";
+import { SITE_URL } from "$lib/config";
+
+interface RssItem {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: string;
+}
+
+export const _channel = {
+  title: "Viktor Andersson",
+  link: `${SITE_URL}/blog`,
+  description: "Thoughts on software engineering, climate tech, and open source.",
+  feedURL: `${SITE_URL}/rss.xml`,
+};
+
+const escapeXml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+export const _buildRssXml = (items: RssItem[], lastBuildDate: string): string =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(_channel.title)}</title>
+    <link>${_channel.link}</link>
+    <description>${escapeXml(_channel.description)}</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${_channel.feedURL}" rel="self" type="application/rss+xml" />
+${items
+  .map(
+    (item) => `    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${item.link}</link>
+      <guid isPermaLink="true">${item.link}</guid>
+      <description>${escapeXml(item.description)}</description>
+      <pubDate>${item.pubDate}</pubDate>
+    </item>`,
+  )
+  .join("\n")}
+  </channel>
+</rss>`;
+
+export const GET = async () => {
+  const posts = getAllPosts();
+
+  const items = posts.map((post) => ({
+    title: post.title,
+    link: `${SITE_URL}/blog/${post.slug}`,
+    description: post.description,
+    pubDate: new Date(post.date).toUTCString(),
+  }));
+
+  const newest = posts[0];
+  const lastBuildDate = new Date(newest?.last_updated || newest?.date || Date.now()).toUTCString();
+
+  return new Response(_buildRssXml(items, lastBuildDate), {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "max-age=0, s-maxage=3600",
+    },
+  });
+};

--- a/apps/frontend/src/tests/rss.xml/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/rss.xml/__snapshots__/server.test.ts.snap
@@ -1,0 +1,22 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`rss.xml should match snapshot 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Viktor Andersson</title>
+    <link>https://viktor.andersson.tech/blog</link>
+    <description>Thoughts on software engineering, climate tech, and open source.</description>
+    <language>en</language>
+    <lastBuildDate>Fri, 20 Mar 2026 00:00:00 GMT</lastBuildDate>
+    <atom:link href="https://viktor.andersson.tech/rss.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Hello &amp; &lt;World&gt;</title>
+      <link>https://viktor.andersson.tech/blog/hello_world</link>
+      <guid isPermaLink="true">https://viktor.andersson.tech/blog/hello_world</guid>
+      <description>A &quot;quoted&quot; post</description>
+      <pubDate>Fri, 20 Mar 2026 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"
+`;

--- a/apps/frontend/src/tests/rss.xml/server.test.ts
+++ b/apps/frontend/src/tests/rss.xml/server.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+
+import { _buildRssXml, _channel } from "../../routes/rss.xml/+server";
+
+const pubDate = "Fri, 20 Mar 2026 00:00:00 GMT";
+
+const testItems = [
+  {
+    title: "Hello & <World>",
+    link: "https://viktor.andersson.tech/blog/hello_world",
+    description: 'A "quoted" post',
+    pubDate,
+  },
+];
+
+describe("rss.xml", () => {
+  it("should produce valid XML", () => {
+    const xml = _buildRssXml(testItems, pubDate);
+    expect(xml).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<rss version="2.0"');
+  });
+
+  it("should include channel metadata + self-referencing atom:link", () => {
+    const xml = _buildRssXml(testItems, pubDate);
+    expect(xml).toContain(`<link>${_channel.link}</link>`);
+    expect(xml).toContain(`<atom:link href="${_channel.feedURL}" rel="self"`);
+    expect(xml).toContain(`<lastBuildDate>${pubDate}</lastBuildDate>`);
+  });
+
+  it("should include item link + permalink guid", () => {
+    const xml = _buildRssXml(testItems, pubDate);
+    expect(xml).toContain("<link>https://viktor.andersson.tech/blog/hello_world</link>");
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://viktor.andersson.tech/blog/hello_world</guid>',
+    );
+  });
+
+  it("should escape XML special characters in free-text fields", () => {
+    const xml = _buildRssXml(testItems, pubDate);
+    expect(xml).toContain("<title>Hello &amp; &lt;World&gt;</title>");
+    expect(xml).toContain("<description>A &quot;quoted&quot; post</description>");
+    // The raw, unescaped form must not leak through and break the document.
+    expect(xml).not.toContain("<World>");
+  });
+
+  it("should match snapshot", () => {
+    const xml = _buildRssXml(testItems, pubDate);
+    expect(xml).toMatchSnapshot();
+  });
+});

--- a/apps/frontend/src/theme.css
+++ b/apps/frontend/src/theme.css
@@ -112,18 +112,20 @@ a:hover {
 /* Heading typography scale — descending ladder, used outside blog prose
    (the `prose` plugin sets its own sizes inside .blog-content).
    h1 = page/display title · h2 = section & card heading · h3/h4 = sub-headings. */
-h1 {
-  @apply text-surface-100 text-4xl font-bold;
-}
+@layer base {
+  h1 {
+    @apply text-surface-100 text-4xl font-bold;
+  }
 
-h2 {
-  @apply text-surface-100 text-2xl font-bold;
-}
+  h2 {
+    @apply text-surface-100 text-2xl font-bold;
+  }
 
-h3 {
-  @apply text-surface-100 text-xl font-bold;
-}
+  h3 {
+    @apply text-surface-100 text-xl font-bold;
+  }
 
-h4 {
-  @apply text-surface-100 text-lg font-bold;
+  h4 {
+    @apply text-surface-100 text-lg font-bold;
+  }
 }


### PR DESCRIPTION
## Summary
On-page technical SEO pass across the site — meaningful headings, a canonical safety net, richer structured data, an RSS feed, and location signals.

## Changes
- **Headings** — every page now has a meaningful `<h1>`: the homepage promotes the visible "Viktor Andersson" name to `<h1>`; section pages carry a clean topical `<h1>` (About, Activity, …) while keeping the `~/path` terminal prompt as `aria-hidden` decoration. Base heading scale moved into `@layer base` so per-instance sizes can override.
- **Canonical** — `<link rel="canonical">` / `og:url` fall back to the current path (trailing slash stripped, origin from `SITE_URL`, not the prerender-placeholder origin) unless the page is `noindex`, so an indexable page can't silently ship canonical-less. Root resolves to the no-slash form, matching the sitemap; the redundant explicit homepage prop is dropped.
- **Structured data / meta** — `article:author` + `profile:first_name`/`last_name` OG tags, `inLanguage` on WebSite/BlogPosting/CollectionPage, and `max-image-preview:large, max-snippet:-1, max-video-preview:-1` on the indexable robots meta.
- **RSS** — prerendered RSS 2.0 feed at `/rss.xml` with XML-escaped fields and RFC-822 dates, plus a **blog-scoped** `<link rel="alternate">` autodiscovery tag (blog pages only, not site-wide).
- **Local / entity signals** — "Malmö, Sweden" in the ProfileCard (homepage + about) and the about meta description, corroborating the existing `homeLocation` JSON-LD.
- **OG image** — rendered as JPEG instead of WebP for reliable rendering across social scrapers (Facebook/LinkedIn/Slack).

Not included: the new blog post (`Flowtracing_Go_Brrrr.md`) — intentionally left for a separate content PR.

## Test plan
- `bun run check:ci`, `bun run lint`, `bun run test:unit` (84 pass, incl. new RSS tests), `bun run build` — all green
- Verified in the prerendered output: exactly one meaningful `<h1>` per page; canonical/`og:url` match the sitemap (no trailing slash); `article:author` / profile / `inLanguage` present; `/rss.xml` valid with escaped content; feed autodiscovery on blog pages only; OG image is a valid 1200×675 JPEG

## Follow-ups (manual, out of repo)
Submit `sitemap.xml` + `rss.xml` in Search Console and Request Indexing on key pages — the changes here aren't credited until Google recrawls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)