### PR TITLE
Add llms.txt + centralize site pages and description

### DIFF
--- a/apps/frontend/src/lib/config.ts
+++ b/apps/frontend/src/lib/config.ts
@@ -3,6 +3,9 @@ import FallbackHeroImage from "$lib/assets/hero_banner.svg?w=1200&h=675&format=j
 
 export const SITE_URL = "https://viktor.andersson.tech";
 
+export const SITE_DESCRIPTION =
+  "Personal website for Viktor Andersson, Software Engineer at Electricity Maps and Digital Design and Innovation graduate";
+
 // Social scrapers (Open Graph, Twitter Cards) and Google's structured-data
 // parser require absolute image URLs, so prefix the Vite asset path.
 export const FALLBACK_HERO_IMAGE = `${SITE_URL}${FallbackHeroImage}`;

--- a/apps/frontend/src/lib/pages.ts
+++ b/apps/frontend/src/lib/pages.ts
@@ -1,0 +1,60 @@
+export interface SiteLink {
+  /** Path relative to the site root. Empty string is the homepage. */
+  path: string;
+  /** Human-readable title, used as llms.txt link text. */
+  title: string;
+  /** One-line description, used as llms.txt link description. */
+  description: string;
+}
+
+export interface SitePage extends SiteLink {
+  /** sitemap.xml <priority>. */
+  priority: string;
+  /** sitemap.xml <changefreq>. */
+  changefreq: string;
+}
+
+/** Canonical list of top-level pages, shared by sitemap.xml and llms.txt. */
+export const SITE_PAGES: SitePage[] = [
+  {
+    path: "",
+    title: "Home",
+    description: "Overview and latest writing",
+    priority: "1.0",
+    changefreq: "weekly",
+  },
+  {
+    path: "/about",
+    title: "About",
+    description: "Background, skills, and contact",
+    priority: "0.8",
+    changefreq: "monthly",
+  },
+  {
+    path: "/activity",
+    title: "Activity",
+    description: "Live GitHub contribution log",
+    priority: "0.7",
+    changefreq: "daily",
+  },
+  {
+    path: "/history",
+    title: "History",
+    description: "Career and education timeline",
+    priority: "0.8",
+    changefreq: "monthly",
+  },
+  {
+    path: "/blog",
+    title: "Blog",
+    description: "Writing on software engineering, climate tech, and open source",
+    priority: "0.9",
+    changefreq: "weekly",
+  },
+];
+
+/** Machine-readable endpoints, surfaced in llms.txt's Optional section (never in the sitemap). */
+export const RESOURCE_LINKS: SiteLink[] = [
+  { path: "/rss.xml", title: "RSS feed", description: "Blog posts as an RSS feed" },
+  { path: "/sitemap.xml", title: "Sitemap", description: "All indexed URLs" },
+];

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -8,18 +8,17 @@
   import { afterNavigate } from "$app/navigation";
   import { page, navigating } from "$app/state";
   import Highlight from "$components/Highlight.svelte";
+  import { SITE_PAGES } from "$lib/pages";
   import { type Snippet } from "svelte";
   import { motion } from "$lib/motion";
   import { cubicOut } from "svelte/easing";
   import { fade } from "svelte/transition";
 
-  const links = [
-    { href: "/", label: "Home", name: "" },
-    { href: "/about", label: "About", name: "about" },
-    { href: "/activity", label: "Activity", name: "activity" },
-    { href: "/history", label: "History", name: "history" },
-    { href: "/blog", label: "Blog", name: "blog" },
-  ] as const;
+  const links = SITE_PAGES.map((page) => ({
+    href: page.path || "/",
+    label: page.title,
+    name: page.path.replace(/^\//, ""),
+  }));
 
   let open = $state(false);
   let mobileMenu = $state<HTMLDetailsElement>();

--- a/apps/frontend/src/routes/+page.server.ts
+++ b/apps/frontend/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import { getAllPosts } from "$lib/blog";
-import { SITE_URL } from "$lib/config";
+import { SITE_URL, SITE_DESCRIPTION } from "$lib/config";
 import {
   createWebSiteSchema,
   createSoftwareSourceCodeSchema,
@@ -14,7 +14,7 @@ const structuredData = [
     "@id": `${SITE_URL}/#website`,
     name: "Viktor Andersson",
     url: SITE_URL,
-    description: "Personal website for Viktor Andersson, Software Engineer at Electricity Maps.",
+    description: SITE_DESCRIPTION,
     author: SITE_OWNER_PERSON_REF,
     publisher: SITE_OWNER_PERSON_REF,
   }),

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -4,10 +4,13 @@
   import ProfileCard from "$components/ProfileCard.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
   import Highlight from "$components/Highlight.svelte";
+  import { SITE_DESCRIPTION } from "$lib/config";
+  import { SITE_PAGES } from "$lib/pages";
 
   let { data }: { data: PageData } = $props();
 
   const blogSlugs = $derived(data.blogSlugs);
+  const treePages = SITE_PAGES.filter((page) => page.path !== "" && page.path !== "/blog");
 </script>
 
 {#snippet treeChar(char: string)}<span class="text-2xl text-surface-500" aria-hidden="true">{char}</span>{/snippet}
@@ -15,7 +18,7 @@
 
 <SEO
   title="Viktor Andersson - Software Engineer"
-  description="Personal website for Viktor Andersson, Software Engineer at Electricity Maps and Digital Design and Innovation graduate"
+  description={SITE_DESCRIPTION}
   structuredData={data.structuredData}
 />
 <div class="page-container">
@@ -23,9 +26,9 @@
   <ProfileCard as="h1" />
   <nav aria-label="Site map" class="font-mono text-lg flex flex-col w-full leading-tight whitespace-pre">
     <span><Highlight>~</Highlight>/</span>
-    {@render treeLink("/about", "about", "├── ")}
-    {@render treeLink("/activity", "activity", "├── ")}
-    {@render treeLink("/history", "history", "├── ")}
+    {#each treePages as page}
+      {@render treeLink(page.path, page.path.slice(1), "├── ")}
+    {/each}
     {@render treeLink("/blog", "blog/", "└─┬ ")}
     {#each blogSlugs as slug}
       {@render treeLink(`/blog/${slug}`, slug, "  ├── ")}

--- a/apps/frontend/src/routes/llms.txt/+server.ts
+++ b/apps/frontend/src/routes/llms.txt/+server.ts
@@ -1,0 +1,55 @@
+export const prerender = true;
+import { getAllPosts } from "$lib/blog";
+import { SITE_URL, SITE_DESCRIPTION } from "$lib/config";
+import { SITE_PAGES, RESOURCE_LINKS, type SiteLink } from "$lib/pages";
+
+interface LlmsLink {
+  title: string;
+  url: string;
+  description: string;
+}
+
+const toLlmsLink = (link: SiteLink): LlmsLink => ({
+  title: link.title,
+  url: `${SITE_URL}${link.path || "/"}`,
+  description: link.description,
+});
+
+export const _sitePages: LlmsLink[] = SITE_PAGES.map(toLlmsLink);
+export const _optionalLinks: LlmsLink[] = RESOURCE_LINKS.map(toLlmsLink);
+
+const _linkList = (links: LlmsLink[]): string =>
+  links.map((link) => `- [${link.title}](${link.url}): ${link.description}`).join("\n");
+
+export const _buildLlmsTxt = (blogLinks: LlmsLink[]): string =>
+  `# Viktor Andersson
+
+> ${SITE_DESCRIPTION}
+
+## Pages
+
+${_linkList(_sitePages)}
+
+## Blog
+
+${_linkList(blogLinks)}
+
+## Optional
+
+${_linkList(_optionalLinks)}
+`;
+
+export const GET = async () => {
+  const blogLinks = getAllPosts().map((post) => ({
+    title: post.title,
+    url: `${SITE_URL}/blog/${post.slug}`,
+    description: post.description,
+  }));
+
+  return new Response(_buildLlmsTxt(blogLinks), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "max-age=0, s-maxage=3600",
+    },
+  });
+};

--- a/apps/frontend/src/routes/sitemap.xml/+server.ts
+++ b/apps/frontend/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,7 @@
 export const prerender = true;
 import { getAllPosts, getAllTags, slugifyTag } from "$lib/blog";
 import { SITE_URL } from "$lib/config";
+import { SITE_PAGES } from "$lib/pages";
 import { PROFILE_DATE_MODIFIED } from "$lib/seo/person";
 
 interface SitemapPage {
@@ -12,13 +13,12 @@ interface SitemapPage {
 
 const profileLastmod = PROFILE_DATE_MODIFIED.split("T")[0];
 
-export const _staticPages = [
-  { path: "", priority: "1.0", changefreq: "weekly", lastmod: profileLastmod },
-  { path: "/blog", priority: "0.9", changefreq: "weekly", lastmod: profileLastmod },
-  { path: "/about", priority: "0.8", changefreq: "monthly", lastmod: profileLastmod },
-  { path: "/activity", priority: "0.7", changefreq: "daily", lastmod: profileLastmod },
-  { path: "/history", priority: "0.8", changefreq: "monthly", lastmod: profileLastmod },
-];
+export const _staticPages: SitemapPage[] = SITE_PAGES.map((page) => ({
+  path: page.path,
+  priority: page.priority,
+  changefreq: page.changefreq,
+  lastmod: profileLastmod,
+}));
 
 export const _buildSitemapXml = (pages: SitemapPage[]): string =>
   `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/frontend/src/tests/llms.txt/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/llms.txt/__snapshots__/server.test.ts.snap
@@ -1,0 +1,25 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`llms.txt should match snapshot 1`] = `
+"# Viktor Andersson
+
+> Personal website for Viktor Andersson, Software Engineer at Electricity Maps and Digital Design and Innovation graduate
+
+## Pages
+
+- [Home](https://viktor.andersson.tech/): Overview and latest writing
+- [About](https://viktor.andersson.tech/about): Background, skills, and contact
+- [Activity](https://viktor.andersson.tech/activity): Live GitHub contribution log
+- [History](https://viktor.andersson.tech/history): Career and education timeline
+- [Blog](https://viktor.andersson.tech/blog): Writing on software engineering, climate tech, and open source
+
+## Blog
+
+- [Hello World](https://viktor.andersson.tech/blog/hello_world): My first post
+
+## Optional
+
+- [RSS feed](https://viktor.andersson.tech/rss.xml): Blog posts as an RSS feed
+- [Sitemap](https://viktor.andersson.tech/sitemap.xml): All indexed URLs
+"
+`;

--- a/apps/frontend/src/tests/llms.txt/server.test.ts
+++ b/apps/frontend/src/tests/llms.txt/server.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test";
+
+import { SITE_DESCRIPTION } from "../../lib/config";
+import { _buildLlmsTxt, _sitePages, _optionalLinks } from "../../routes/llms.txt/+server";
+
+const testPosts = [
+  {
+    title: "Hello World",
+    url: "https://viktor.andersson.tech/blog/hello_world",
+    description: "My first post",
+  },
+];
+
+describe("llms.txt", () => {
+  it("should start with the H1 title", () => {
+    const txt = _buildLlmsTxt(testPosts);
+    expect(txt).toStartWith("# Viktor Andersson");
+  });
+
+  it("should include the summary as a blockquote", () => {
+    const txt = _buildLlmsTxt(testPosts);
+    expect(txt).toContain(`> ${SITE_DESCRIPTION}`);
+  });
+
+  it("should include the required section headers", () => {
+    const txt = _buildLlmsTxt(testPosts);
+    expect(txt).toContain("## Pages");
+    expect(txt).toContain("## Blog");
+    expect(txt).toContain("## Optional");
+  });
+
+  it("should render links in `- [title](url): description` format", () => {
+    const txt = _buildLlmsTxt(testPosts);
+    expect(txt).toContain(
+      "- [Hello World](https://viktor.andersson.tech/blog/hello_world): My first post",
+    );
+    expect(txt).toContain(
+      `- [${_sitePages[0].title}](${_sitePages[0].url}): ${_sitePages[0].description}`,
+    );
+    expect(txt).toContain(
+      `- [${_optionalLinks[0].title}](${_optionalLinks[0].url}): ${_optionalLinks[0].description}`,
+    );
+  });
+
+  it("should match snapshot", () => {
+    const txt = _buildLlmsTxt(testPosts);
+    expect(txt).toMatchSnapshot();
+  });
+});

--- a/apps/frontend/src/tests/sitemap.xml/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/sitemap.xml/__snapshots__/server.test.ts.snap
@@ -10,12 +10,6 @@ exports[`sitemap.xml should match snapshot 1`] = `
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://viktor.andersson.tech/blog</loc>
-    <lastmod>YYYY-MM-DD</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://viktor.andersson.tech/about</loc>
     <lastmod>YYYY-MM-DD</lastmod>
     <changefreq>monthly</changefreq>
@@ -32,6 +26,12 @@ exports[`sitemap.xml should match snapshot 1`] = `
     <lastmod>YYYY-MM-DD</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://viktor.andersson.tech/blog</loc>
+    <lastmod>YYYY-MM-DD</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://viktor.andersson.tech/blog/hello_world</loc>


### PR DESCRIPTION
## Summary
Follow-up to #593 (merged). Adds a machine-readable `/llms.txt` and refactors the top-level page list into a single shared registry, so the sitemap, llms.txt, navbar, and homepage tree stop each maintaining their own copy.

## Changes
- **`/llms.txt`** — new prerendered endpoint mirroring the `rss.xml` / `sitemap.xml` pattern. Emits a spec-valid Markdown index: `# H1` → `>` summary → `## Pages` / `## Blog` / `## Optional` link lists, generated from `getAllPosts()` so it stays current. This is what Lighthouse's new "Agentic Browsing" audit checks for (presence + validity); per Google it has **no** Search-ranking or AI-Overviews effect.
- **Shared page registry** — new `src/lib/pages.ts` exports `SITE_PAGES` (top-level pages) + `RESOURCE_LINKS` (RSS/sitemap). It's now the single source for: `sitemap.xml`, `llms.txt`, the navbar (`+layout.svelte`), and the homepage tree's leaf links (`+page.svelte`). The `blog/` tree branch stays explicit (nested posts + `...` more-link — a one-off structure not worth generalizing).
- **Unified site description** — new `SITE_DESCRIPTION` (`config.ts`) collapses three near-duplicate strings (homepage `<meta description>`, WebSite JSON-LD, llms summary) into one constant.

## Test plan
- `bun run format`, `bun run lint`, `bun run check:ci` (0 errors), `bun run test:unit` (89 frontend + 19 backend pass, incl. new llms.txt tests) — all green
- Verified in prerendered output: `/llms.txt` is spec-valid; navbar + homepage tree render in the same order as before; `sitemap.xml` / `llms.txt` reflect the shared registry; `<meta>` / WebSite JSON-LD / llms summary are byte-identical

Not included: the WIP blog post (`Flowtracing_Go_Brrrr.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
