### PR TITLE
backend: Enable Workers Cache in front of the worker

### DIFF
--- a/apps/backend/wrangler.jsonc
+++ b/apps/backend/wrangler.jsonc
@@ -5,6 +5,8 @@
   "workers_dev": false,
   "compatibility_flags": ["nodejs_als"],
   "compatibility_date": "2026-03-10",
+  // Global edge cache in front of the worker; honors the Cache-Control set in src/index.ts.
+  "cache": { "enabled": true },
   "observability": {
     "logs": {
       "enabled": true,


### PR DESCRIPTION
## What

Enables [Workers Cache](https://developers.cloudflare.com/workers/cache/) on the backend worker via `"cache": { "enabled": true }` in `apps/backend/wrangler.jsonc`.

## Why

`portfolio-backend` is zoneless — `workers_dev: false`, no routes, reachable only through the frontend's `BACKEND` service binding. In that setup the in-worker Cache API (which `hono/cache` uses) isn't guaranteed to function and, even where it does, never replicates beyond a single datacenter — so the 1-hour cap can degrade to a per-datacenter cache or a silent no-op, letting `/activity` views hit GitHub directly.

Workers Cache is a **global** edge cache placed in front of the worker. It:
- honors the existing `Cache-Control: max-age=3600` set in `src/index.ts` — no code change,
- is consulted **before** smart placement, so a hit is served at the edge and the worker never runs (no CPU billed on hits),
- respects the local-dev `no-store` path, so iteration still sees live data.

## Cost

Enabling caching flips the (normally free) service-binding subrequests to billed at the standard request rate, even on hits. At personal-site traffic this stays comfortably inside the free tier, and it's offset by CPU-time savings on hits.

## Not included

- **Frontend cache** left off intentionally: ~all traffic is free static assets (would flip to billed), and `/activity` sends `no-cache` + ETag so it'd revalidate through the worker anyway.
- **Smart placement** already enabled on both workers — no change.
- **`hono/cache` in `src/index.ts`** left in place as a now-redundant inner layer; simplify only after confirming edge hits.

## Verification

`wrangler deploy --dry-run` parses the config and resolves bindings cleanly. After deploy: load `/activity` a few times and confirm in the dashboard (invocation logs on) that repeated loads stop invoking the backend. If hits don't appear, bump `compatibility_date` (currently `2026-03-10`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)