### PR TITLE
frontend: Unify tag indexing, split post chunks, make builds reproducible

### DIFF
--- a/apps/frontend/src/components/blog/BlogPostList.svelte
+++ b/apps/frontend/src/components/blog/BlogPostList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { BlogPostMeta } from "$lib/blog";
+  import { pageURL } from "$lib/helpers/paginationURLs";
   import type { LucideIcon } from "@lucide/svelte";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
@@ -17,8 +18,7 @@
 
   const box = "inline-flex items-center justify-center size-8";
 
-  const pageHref = (page: number): string =>
-    page === 1 ? baseHref : `${baseHref}/page/${page}`;
+  const pageHref = (page: number): string => pageURL(baseHref, page);
 </script>
 
 {#snippet blogPostCard(post: BlogPostMeta, last: boolean)}

--- a/apps/frontend/src/lib/blog.server.ts
+++ b/apps/frontend/src/lib/blog.server.ts
@@ -1,0 +1,39 @@
+import type { BlogPostMeta } from "$lib/blog";
+
+import { slugFromPath } from "$lib/blog";
+
+const WORDS_PER_MINUTE = 200;
+
+const calculateReadingTime = (raw: string): number => {
+  const body = raw.replace(/^---[\s\S]*?---/, "").trim();
+  const words = body.match(/\S+/g)?.length ?? 0;
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+};
+
+/**
+ * Server-only: the eager globs below compile to static imports of every post, so
+ * anything the client can reach must not import this module. The `.server` suffix
+ * makes SvelteKit enforce that — see $lib/blog.ts for the glob-free helpers.
+ */
+export const getAllPosts = (): BlogPostMeta[] => {
+  const modules = import.meta.glob("$blogs/*.md", { eager: true });
+  const rawPaths = import.meta.glob("$blogs/*.md", {
+    eager: true,
+    query: "?raw",
+    import: "default",
+  });
+  const posts: BlogPostMeta[] = [];
+
+  for (const path in modules) {
+    const file = modules[path] as any;
+    const metadata = file?.metadata as Record<string, any> | undefined;
+    const raw = (rawPaths[path] as string) ?? "";
+    const slug = slugFromPath(path);
+
+    if (metadata && slug) {
+      posts.push({ ...metadata, slug, readingTime: calculateReadingTime(raw) } as BlogPostMeta);
+    }
+  }
+
+  return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+};

--- a/apps/frontend/src/lib/blog.test.ts
+++ b/apps/frontend/src/lib/blog.test.ts
@@ -1,0 +1,65 @@
+import { getAllTagSlugs, getPostsForTag, isTagIndexable, slugifyTag } from "$lib/blog";
+import { describe, expect, it } from "bun:test";
+
+import { makePost, postsTagged } from "../tests/fixtures/posts";
+
+describe("slugifyTag", () => {
+  it("lowercases and collapses non-alphanumeric runs", () => {
+    expect(slugifyTag("Google Cloud")).toBe("google-cloud");
+    expect(slugifyTag("Node.js")).toBe("node-js");
+  });
+
+  it("strips leading and trailing dashes", () => {
+    expect(slugifyTag("...Vite!")).toBe("vite");
+  });
+
+  it("is idempotent", () => {
+    const slug = slugifyTag("Google Cloud");
+    expect(slugifyTag(slug)).toBe(slug);
+  });
+
+  it("returns an empty string for punctuation-only tags", () => {
+    expect(slugifyTag("+++")).toBe("");
+  });
+});
+
+describe("getAllTagSlugs", () => {
+  it("dedupes tags that differ raw but share a slug", () => {
+    const posts = postsTagged("google-cloud", 2, (i) =>
+      i === 0 ? ["Google Cloud"] : ["google-cloud"],
+    );
+    expect(getAllTagSlugs(posts)).toEqual(["google-cloud"]);
+  });
+
+  it("drops tags that slugify to an empty string", () => {
+    expect(getAllTagSlugs([makePost({ slug: "a", tags: ["+++", "vite"] })])).toEqual(["vite"]);
+  });
+
+  it("sorts the slugs and tolerates posts without tags", () => {
+    const posts = [makePost({ slug: "a", tags: ["vite", "arm"] }), makePost({ slug: "b" })];
+    expect(getAllTagSlugs(posts)).toEqual(["arm", "vite"]);
+  });
+});
+
+describe("getPostsForTag", () => {
+  it("matches on slug, not raw tag text", () => {
+    const posts = postsTagged("google-cloud", 3, (i) =>
+      i === 2 ? ["vite"] : [i === 0 ? "Google Cloud" : "google-cloud"],
+    );
+    expect(getPostsForTag(posts, "google-cloud").map((p) => p.slug)).toEqual([
+      "google-cloud-0",
+      "google-cloud-1",
+    ]);
+  });
+
+  it("preserves the order of the input posts", () => {
+    const posts = postsTagged("vite", 3, (i) => (i === 1 ? ["arm"] : ["vite"]));
+    expect(getPostsForTag(posts, "vite").map((p) => p.slug)).toEqual(["vite-0", "vite-2"]);
+  });
+});
+
+describe("isTagIndexable", () => {
+  it("excludes tags with no posts", () => {
+    expect(isTagIndexable([])).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/blog.ts
+++ b/apps/frontend/src/lib/blog.ts
@@ -10,55 +10,29 @@ export interface BlogPostMeta {
   readingTime: number;
 }
 
-const WORDS_PER_MINUTE = 200;
-
-const calculateReadingTime = (raw: string): number => {
-  const body = raw.replace(/^---[\s\S]*?---/, "").trim();
-  const words = body.match(/\S+/g)?.length ?? 0;
-  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
-};
-
+// Glob-free by design: the client reaches this module for slugFromPath/slugifyTag, so
+// an eager import.meta.glob here would pull every post into the client bundle. Post
+// loading lives in $lib/blog.server.ts (build-time) and $lib/blog-loader.ts (per-post).
 export const slugFromPath = (path: string): string | undefined =>
   path.split("/").at(-1)?.replace(/\.md$/, "").toLowerCase();
-
-export const getAllPosts = (): BlogPostMeta[] => {
-  const modules = import.meta.glob("$blogs/*.md", { eager: true });
-  const rawPaths = import.meta.glob("$blogs/*.md", {
-    eager: true,
-    query: "?raw",
-    import: "default",
-  });
-  const posts: BlogPostMeta[] = [];
-
-  for (const path in modules) {
-    const file = modules[path] as any;
-    const metadata = file?.metadata as Record<string, any> | undefined;
-    const raw = (rawPaths[path] as string) ?? "";
-    const slug = slugFromPath(path);
-
-    if (metadata && slug) {
-      posts.push({ ...metadata, slug, readingTime: calculateReadingTime(raw) } as BlogPostMeta);
-    }
-  }
-
-  return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-};
-
-export const getAllTags = (posts: BlogPostMeta[]): string[] => {
-  const tagSet = new Set<string>();
-  for (const post of posts) {
-    for (const tag of post.tags ?? []) {
-      tagSet.add(tag.toLowerCase());
-    }
-  }
-  return [...tagSet].sort();
-};
 
 export const slugifyTag = (tag: string): string =>
   tag
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
+
+/** Minimum posts before a tag listing is worth indexing. Drives both the robots meta and sitemap membership. */
+export const TAG_INDEX_MIN_POSTS = 4;
+
+export const getAllTagSlugs = (posts: BlogPostMeta[]): string[] =>
+  [...new Set(posts.flatMap((p) => p.tags ?? []).map(slugifyTag))].filter(Boolean).sort();
+
+export const getPostsForTag = (posts: BlogPostMeta[], tagSlug: string): BlogPostMeta[] =>
+  posts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug));
+
+export const isTagIndexable = (tagPosts: BlogPostMeta[]): boolean =>
+  tagPosts.length >= TAG_INDEX_MIN_POSTS;
 
 export const paginatePosts = (posts: BlogPostMeta[], currentPage: number) => {
   const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));

--- a/apps/frontend/src/lib/helpers/paginationURLs.test.ts
+++ b/apps/frontend/src/lib/helpers/paginationURLs.test.ts
@@ -1,0 +1,50 @@
+import { buildPaginationURLs, pageURL } from "$lib/helpers/paginationURLs";
+import { describe, expect, it } from "bun:test";
+
+describe("pageURL", () => {
+  it("leaves page 1 at the base, unsuffixed", () => {
+    expect(pageURL("/blog", 1)).toBe("/blog");
+  });
+
+  it("appends /page/N beyond page 1", () => {
+    expect(pageURL("/blog", 2)).toBe("/blog/page/2");
+  });
+
+  it("works for relative nav hrefs and absolute SEO URLs alike", () => {
+    expect(pageURL("/blog/tag/vite", 3)).toBe("/blog/tag/vite/page/3");
+    expect(pageURL("https://viktor.andersson.tech/blog", 3)).toBe(
+      "https://viktor.andersson.tech/blog/page/3",
+    );
+  });
+});
+
+describe("buildPaginationURLs", () => {
+  it("omits prev on the first page and next on the last", () => {
+    expect(buildPaginationURLs("/blog", 1, 3)).toEqual({
+      canonicalURL: "/blog",
+      prevURL: undefined,
+      nextURL: "/blog/page/2",
+    });
+    expect(buildPaginationURLs("/blog", 3, 3)).toEqual({
+      canonicalURL: "/blog/page/3",
+      prevURL: "/blog/page/2",
+      nextURL: undefined,
+    });
+  });
+
+  it("points prev at the bare base from page 2", () => {
+    expect(buildPaginationURLs("/blog", 2, 3)).toEqual({
+      canonicalURL: "/blog/page/2",
+      prevURL: "/blog",
+      nextURL: "/blog/page/3",
+    });
+  });
+
+  it("omits both on a single-page listing", () => {
+    expect(buildPaginationURLs("/blog", 1, 1)).toEqual({
+      canonicalURL: "/blog",
+      prevURL: undefined,
+      nextURL: undefined,
+    });
+  });
+});

--- a/apps/frontend/src/lib/helpers/paginationURLs.ts
+++ b/apps/frontend/src/lib/helpers/paginationURLs.ts
@@ -6,7 +6,8 @@ interface PaginationURLs {
 
 // Pagination uses path segments (/page/2) rather than query strings, because
 // the site is fully prerendered and query strings are ignored for static pages.
-const pageURL = (baseURL: string, page: number): string =>
+// Format-only, so it serves both absolute SEO URLs and relative nav hrefs.
+export const pageURL = (baseURL: string, page: number): string =>
   page === 1 ? baseURL : `${baseURL}/page/${page}`;
 
 export const buildPaginationURLs = (

--- a/apps/frontend/src/lib/seo/components/SEO.svelte
+++ b/apps/frontend/src/lib/seo/components/SEO.svelte
@@ -6,8 +6,8 @@
     FALLBACK_HERO_IMAGE_WIDTH,
     SITE_URL,
   } from "$lib/config";
-  import type { StructuredDataSchema } from "..";
-  import { toJsonLd } from "..";
+  import type { Robots, StructuredDataSchema } from "..";
+  import { ROBOTS, toJsonLd } from "..";
 
   let {
     title,
@@ -16,7 +16,7 @@
     prevURL,
     nextURL,
     structuredData,
-    noIndex = false,
+    robots = ROBOTS.default,
     image = FALLBACK_HERO_IMAGE,
     imageWidth = FALLBACK_HERO_IMAGE_WIDTH,
     imageHeight = FALLBACK_HERO_IMAGE_HEIGHT,
@@ -32,7 +32,7 @@
     prevURL?: string;
     nextURL?: string;
     structuredData?: StructuredDataSchema | StructuredDataSchema[];
-    noIndex?: boolean;
+    robots?: Robots;
     image?: string;
     imageWidth?: number;
     imageHeight?: number;
@@ -48,7 +48,8 @@
 
   // Default to the current path (no trailing slash); noindex pages get no canonical.
   const resolvedCanonicalURL = $derived(
-    canonicalURL ?? (noIndex ? undefined : SITE_URL + page.url.pathname.replace(/\/$/, "")),
+    canonicalURL ??
+      (robots.startsWith("noindex") ? undefined : SITE_URL + page.url.pathname.replace(/\/$/, "")),
   );
 </script>
 
@@ -100,12 +101,5 @@
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
 
-  {#if noIndex}
-    <meta name="robots" content="noindex, nofollow" />
-  {:else}
-    <meta
-      name="robots"
-      content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
-    />
-  {/if}
+  <meta name="robots" content={robots} />
 </svelte:head>

--- a/apps/frontend/src/lib/seo/index.ts
+++ b/apps/frontend/src/lib/seo/index.ts
@@ -1,5 +1,15 @@
 import { SITE_URL } from "$lib/config";
 
+/** robots directives, one per indexing policy. Pages pick a policy; they never spell out directives. */
+export const ROBOTS = {
+  default: "index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1",
+  /** Listings too thin to index, still crawled so they pass equity to the posts they link. */
+  thinArchive: "noindex, follow",
+  error: "noindex, nofollow",
+} as const;
+
+export type Robots = (typeof ROBOTS)[keyof typeof ROBOTS];
+
 const postalAddressType = "PostalAddress" as const;
 const placeType = "Place" as const;
 const organizationType = "Organization" as const;

--- a/apps/frontend/src/routes/+error.svelte
+++ b/apps/frontend/src/routes/+error.svelte
@@ -4,12 +4,13 @@
   import StatusPage from "$components/StatusPage.svelte";
   import Highlight from "$components/Highlight.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
+  import { ROBOTS } from "$lib/seo";
 </script>
 
 <SEO
   title={`Error ${page.status}`}
   description={page.error?.message || "An unexpected error occurred."}
-  noIndex={true}
+  robots={ROBOTS.error}
 />
 
 <StatusPage

--- a/apps/frontend/src/routes/+page.server.ts
+++ b/apps/frontend/src/routes/+page.server.ts
@@ -1,4 +1,4 @@
-import { getAllPosts } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { SITE_URL, SITE_DESCRIPTION } from "$lib/config";
 import {
   createWebSiteSchema,

--- a/apps/frontend/src/routes/blog/[slug]/+error.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+error.svelte
@@ -4,12 +4,13 @@
   import StatusPage from "$components/StatusPage.svelte";
   import Highlight from "$components/Highlight.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
+  import { ROBOTS } from "$lib/seo";
 </script>
 
 <SEO
   title={`Blog Post Error ${page.status}`}
   description={page.error?.message || "Sorry, there was a problem loading this blog post."}
-  noIndex={true}
+  robots={ROBOTS.error}
 />
 
 <StatusPage

--- a/apps/frontend/src/routes/blog/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/[slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { getAllPosts } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { FALLBACK_HERO_IMAGE, SITE_URL } from "$lib/config";
 import {
   createArticleSchema,

--- a/apps/frontend/src/routes/blog/listing.ts
+++ b/apps/frontend/src/routes/blog/listing.ts
@@ -1,4 +1,5 @@
-import { getAllPosts, paginatePosts } from "$lib/blog";
+import { paginatePosts } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { BLOG_DESCRIPTION, SITE_URL } from "$lib/config";
 import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
 import {
@@ -12,7 +13,6 @@ import {
 export const loadBlogListing = (page: number) => {
   const posts = getAllPosts();
   const paginated = paginatePosts(posts, page);
-  const allSlugs = posts.map((p) => p.slug);
 
   const { canonicalURL, prevURL, nextURL } = buildPaginationURLs(
     `${SITE_URL}/blog`,
@@ -25,7 +25,7 @@ export const loadBlogListing = (page: number) => {
       name: "Blog",
       description: BLOG_DESCRIPTION,
       url: canonicalURL,
-      mainEntity: createItemListSchema(allSlugs.map((slug) => `${SITE_URL}/blog/${slug}`)),
+      mainEntity: createItemListSchema(posts.map((p) => `${SITE_URL}/blog/${p.slug}`)),
       isPartOf: SITE_WEBSITE_REF,
     }),
     createBreadcrumbListSchema([{ name: "Home", url: SITE_URL }, { name: "Blog" }]),
@@ -33,7 +33,6 @@ export const loadBlogListing = (page: number) => {
 
   return {
     ...paginated,
-    allSlugs,
     description: BLOG_DESCRIPTION,
     structuredData,
     canonicalURL,

--- a/apps/frontend/src/routes/blog/page/[page]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/page/[page]/+page.server.ts
@@ -1,4 +1,5 @@
-import { getAllPosts, PAGE_SIZE, parsePageParam } from "$lib/blog";
+import { PAGE_SIZE, parsePageParam } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { error, redirect } from "@sveltejs/kit";
 
 import type { PageServerLoadEvent } from "./$types";

--- a/apps/frontend/src/routes/blog/tag/[tag]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/+page.server.ts
@@ -1,13 +1,11 @@
-import { getAllPosts, getAllTags, slugifyTag } from "$lib/blog";
+import { getAllTagSlugs } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 
 import type { PageServerLoadEvent } from "./$types";
 
 import { loadTagListing } from "./listing";
 
-export const entries = () => {
-  const posts = getAllPosts();
-  const tags = getAllTags(posts);
-  return tags.map((tag) => ({ tag: slugifyTag(tag) }));
-};
+export const entries = () => getAllTagSlugs(getAllPosts()).map((tag) => ({ tag }));
 
-export const load = async ({ params }: PageServerLoadEvent) => loadTagListing(params.tag, 1);
+export const load = async ({ params }: PageServerLoadEvent) =>
+  loadTagListing(params.tag, 1, getAllPosts());

--- a/apps/frontend/src/routes/blog/tag/[tag]/+page.svelte
+++ b/apps/frontend/src/routes/blog/tag/[tag]/+page.svelte
@@ -1,25 +1,8 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  import SEO from "$lib/seo/components/SEO.svelte";
-  import BlogPostList from "$components/blog/BlogPostList.svelte";
-  import TitleText from "$components/TitleText.svelte";
+  import TagListing from "./TagListing.svelte";
 
   let { data }: { data: PageData } = $props();
 </script>
 
-<SEO
-  noIndex={data.totalPosts < 4}
-  title={`Viktor Andersson | #${data.displayTag}${data.currentPage > 1 ? ` — Page ${data.currentPage}` : ""}`}
-  description={data.description}
-  canonicalURL={data.canonicalURL}
-  prevURL={data.prevURL}
-  nextURL={data.nextURL}
-  structuredData={data.structuredData}
-/>
-
-<div class="page-container">
-
-  <TitleText path="blog/tag/{data.tag}" heading="Posts tagged #{data.displayTag}" subtitle="Posts tagged with #{data.displayTag}" />
-
-  <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} baseHref="/blog/tag/{data.tag}" />
-</div>
+<TagListing {data} />

--- a/apps/frontend/src/routes/blog/tag/[tag]/TagListing.svelte
+++ b/apps/frontend/src/routes/blog/tag/[tag]/TagListing.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import BlogPostList from "$components/blog/BlogPostList.svelte";
+  import TitleText from "$components/TitleText.svelte";
+  import SEO from "$lib/seo/components/SEO.svelte";
+
+  import type { loadTagListing } from "./listing";
+
+  let { data }: { data: ReturnType<typeof loadTagListing> } = $props();
+</script>
+
+<SEO
+  robots={data.robots}
+  title={data.title}
+  description={data.description}
+  canonicalURL={data.canonicalURL}
+  prevURL={data.prevURL}
+  nextURL={data.nextURL}
+  structuredData={data.structuredData}
+/>
+
+<div class="page-container">
+  <TitleText
+    path="blog/tag/{data.tag}"
+    heading="Posts tagged #{data.displayTag}"
+    subtitle="Posts tagged with #{data.displayTag}"
+  />
+
+  <BlogPostList
+    posts={data.pagedPosts}
+    currentPage={data.currentPage}
+    totalPages={data.totalPages}
+    baseHref="/blog/tag/{data.tag}"
+  />
+</div>

--- a/apps/frontend/src/routes/blog/tag/[tag]/listing.test.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/listing.test.ts
@@ -1,0 +1,33 @@
+import { TAG_INDEX_MIN_POSTS } from "$lib/blog";
+import { ROBOTS } from "$lib/seo";
+import { describe, expect, it } from "bun:test";
+
+import { postsTagged } from "../../../../tests/fixtures/posts";
+import { loadTagListing } from "./listing";
+
+describe("loadTagListing", () => {
+  it("slugifies the tag param rather than only lowercasing it", () => {
+    const data = loadTagListing("Google Cloud", 1, postsTagged("google-cloud", 1));
+    expect(data.tag).toBe("google-cloud");
+    expect(data.canonicalURL).toBe("https://viktor.andersson.tech/blog/tag/google-cloud");
+    expect(data.pagedPosts).toHaveLength(1);
+  });
+
+  it("derives displayTag from the newest matching post's raw tag", () => {
+    const posts = postsTagged("google-cloud", 2, (i) =>
+      i === 0 ? ["Google Cloud"] : ["google-cloud"],
+    );
+    expect(loadTagListing("google-cloud", 1, posts).displayTag).toBe("Google Cloud");
+  });
+
+  it("thins the robots directive below the threshold", () => {
+    const posts = postsTagged("vite", TAG_INDEX_MIN_POSTS - 1);
+    expect(loadTagListing("vite", 1, posts).robots).toBe(ROBOTS.thinArchive);
+  });
+
+  it("titles page 1 without a page number and later pages with one", () => {
+    const posts = postsTagged("vite", 1);
+    expect(loadTagListing("vite", 1, posts).title).toBe("Viktor Andersson | #vite");
+    expect(loadTagListing("vite", 2, posts).title).toBe("Viktor Andersson | #vite — Page 2");
+  });
+});

--- a/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
@@ -1,4 +1,6 @@
-import { getAllPosts, paginatePosts, slugifyTag } from "$lib/blog";
+import type { BlogPostMeta } from "$lib/blog";
+
+import { getPostsForTag, isTagIndexable, paginatePosts, slugifyTag } from "$lib/blog";
 import { SITE_URL } from "$lib/config";
 import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
 import {
@@ -7,23 +9,22 @@ import {
   createCollectionPageSchema,
   createDefinedTermSchema,
   createItemListSchema,
+  ROBOTS,
   SITE_WEBSITE_REF,
 } from "$lib/seo";
 
 /** Shared load logic for /blog/tag/[tag] and /blog/tag/[tag]/page/[page]. */
-export const loadTagListing = (tag: string, page: number) => {
-  const posts = getAllPosts();
-  const tagSlug = tag.toLowerCase();
+export const loadTagListing = (tag: string, page: number, posts: BlogPostMeta[]) => {
+  const tagSlug = slugifyTag(tag);
 
-  const filtered = posts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug));
+  const filtered = getPostsForTag(posts, tagSlug);
 
   // Derive display name from the first matching post's original tag (newest post wins)
-  const displayTag =
-    posts.flatMap((p) => p.tags ?? []).find((t) => slugifyTag(t) === tagSlug) ?? tagSlug;
+  const displayTag = filtered[0]?.tags?.find((t) => slugifyTag(t) === tagSlug) ?? tagSlug;
 
   const paginated = paginatePosts(filtered, page);
-  const allSlugs = filtered.map((p) => p.slug);
-  const totalPosts = allSlugs.length;
+  const totalPosts = filtered.length;
+  const robots = isTagIndexable(filtered) ? ROBOTS.default : ROBOTS.thinArchive;
 
   const baseURL = `${SITE_URL}/blog/tag/${tagSlug}`;
   const { canonicalURL, prevURL, nextURL } = buildPaginationURLs(
@@ -39,7 +40,7 @@ export const loadTagListing = (tag: string, page: number) => {
       name: `Posts tagged "${displayTag}"`,
       description,
       url: canonicalURL,
-      mainEntity: createItemListSchema(allSlugs.map((slug) => `${SITE_URL}/blog/${slug}`)),
+      mainEntity: createItemListSchema(filtered.map((p) => `${SITE_URL}/blog/${p.slug}`)),
       isPartOf: [createCollectionPageRefSchema(`${SITE_URL}/blog`), SITE_WEBSITE_REF],
       about: createDefinedTermSchema({ name: displayTag }),
     }),
@@ -54,8 +55,8 @@ export const loadTagListing = (tag: string, page: number) => {
     ...paginated,
     tag: tagSlug,
     displayTag,
-    allSlugs,
-    totalPosts,
+    title: `Viktor Andersson | #${displayTag}${page > 1 ? ` — Page ${page}` : ""}`,
+    robots,
     description,
     structuredData,
     canonicalURL,

--- a/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.server.ts
@@ -1,4 +1,5 @@
-import { getAllPosts, getAllTags, PAGE_SIZE, parsePageParam, slugifyTag } from "$lib/blog";
+import { getAllTagSlugs, getPostsForTag, PAGE_SIZE, parsePageParam, slugifyTag } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { error, redirect } from "@sveltejs/kit";
 
 import type { PageServerLoadEvent } from "./$types";
@@ -8,10 +9,8 @@ import { loadTagListing } from "../../listing";
 export const entries = () => {
   const posts = getAllPosts();
   const result: { tag: string; page: string }[] = [];
-  for (const tag of getAllTags(posts)) {
-    const tagSlug = slugifyTag(tag);
-    const count = posts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug)).length;
-    const totalPages = Math.ceil(count / PAGE_SIZE);
+  for (const tagSlug of getAllTagSlugs(posts)) {
+    const totalPages = Math.ceil(getPostsForTag(posts, tagSlug).length / PAGE_SIZE);
     for (let p = 2; p <= totalPages; p++) {
       result.push({ tag: tagSlug, page: String(p) });
     }
@@ -22,9 +21,9 @@ export const entries = () => {
 export const load = async ({ params }: PageServerLoadEvent) => {
   const page = parsePageParam(params.page);
   if (!page) error(404, "Page not found");
-  if (page === 1) redirect(308, `/blog/tag/${params.tag.toLowerCase()}`);
+  if (page === 1) redirect(308, `/blog/tag/${slugifyTag(params.tag)}`);
 
-  const data = loadTagListing(params.tag, page);
+  const data = loadTagListing(params.tag, page, getAllPosts());
   if (page > data.totalPages) error(404, "Page not found");
 
   return data;

--- a/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/tag/[tag]/page/[page]/+page.svelte
@@ -1,25 +1,8 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  import SEO from "$lib/seo/components/SEO.svelte";
-  import BlogPostList from "$components/blog/BlogPostList.svelte";
-  import TitleText from "$components/TitleText.svelte";
+  import TagListing from "../../TagListing.svelte";
 
   let { data }: { data: PageData } = $props();
 </script>
 
-<SEO
-  noIndex={data.totalPosts < 4}
-  title={`Viktor Andersson | #${data.displayTag} — Page ${data.currentPage}`}
-  description={data.description}
-  canonicalURL={data.canonicalURL}
-  prevURL={data.prevURL}
-  nextURL={data.nextURL}
-  structuredData={data.structuredData}
-/>
-
-<div class="page-container">
-
-  <TitleText path="blog/tag/{data.tag}" heading="Posts tagged #{data.displayTag}" subtitle="Posts tagged with #{data.displayTag}" />
-
-  <BlogPostList posts={data.pagedPosts} currentPage={data.currentPage} totalPages={data.totalPages} baseHref="/blog/tag/{data.tag}" />
-</div>
+<TagListing {data} />

--- a/apps/frontend/src/routes/llms.txt/+server.ts
+++ b/apps/frontend/src/routes/llms.txt/+server.ts
@@ -1,5 +1,5 @@
 export const prerender = true;
-import { getAllPosts } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { SITE_URL, SITE_DESCRIPTION } from "$lib/config";
 import { SITE_PAGES, RESOURCE_LINKS, type SiteLink } from "$lib/pages";
 

--- a/apps/frontend/src/routes/rss.xml/+server.ts
+++ b/apps/frontend/src/routes/rss.xml/+server.ts
@@ -1,5 +1,5 @@
 export const prerender = true;
-import { getAllPosts } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { BLOG_DESCRIPTION, SITE_URL } from "$lib/config";
 
 interface RssItem {

--- a/apps/frontend/src/routes/sitemap.xml/+server.ts
+++ b/apps/frontend/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,10 @@
 export const prerender = true;
-import { getAllPosts, getAllTags, slugifyTag } from "$lib/blog";
+import type { BlogPostMeta } from "$lib/blog";
+
+import { getAllTagSlugs, getPostsForTag, isTagIndexable } from "$lib/blog";
+import { getAllPosts } from "$lib/blog.server";
 import { SITE_URL } from "$lib/config";
+import { formatDate } from "$lib/helpers/formatDate";
 import { SITE_PAGES } from "$lib/pages";
 import { PROFILE_DATE_MODIFIED } from "$lib/seo/person";
 
@@ -13,12 +17,28 @@ interface SitemapPage {
 
 const profileLastmod = PROFILE_DATE_MODIFIED.split("T")[0];
 
+const postLastmod = (post: BlogPostMeta): string => formatDate(post.last_updated || post.date);
+
 export const _staticPages: SitemapPage[] = SITE_PAGES.map((page) => ({
   path: page.path,
   priority: page.priority,
   changefreq: page.changefreq,
   lastmod: profileLastmod,
 }));
+
+export const _tagSitemapPages = (posts: BlogPostMeta[]): SitemapPage[] =>
+  getAllTagSlugs(posts).flatMap((tagSlug) => {
+    const tagPosts = getPostsForTag(posts, tagSlug);
+    if (!isTagIndexable(tagPosts)) return [];
+    return [
+      {
+        path: `/blog/tag/${tagSlug}`,
+        priority: "0.6",
+        changefreq: "weekly",
+        lastmod: postLastmod(tagPosts[0]),
+      },
+    ];
+  });
 
 export const _buildSitemapXml = (pages: SitemapPage[]): string =>
   `<?xml version="1.0" encoding="UTF-8"?>
@@ -42,28 +62,16 @@ export const GET = async () => {
     path: `/blog/${post.slug}`,
     priority: "0.7",
     changefreq: "monthly",
-    lastmod: new Date(post.last_updated || post.date).toISOString().split("T")[0],
+    lastmod: postLastmod(post),
   }));
 
   // lastmod for /blog = newest post's last_updated or date
-  const newestPostDate = new Date(allPosts[0].last_updated || allPosts[0].date)
-    .toISOString()
-    .split("T")[0];
+  const newestPostDate = postLastmod(allPosts[0]);
 
   // lastmod for homepage = newest post's original date (homepage only uses slugs)
-  const newestPostOriginalDate = new Date(allPosts[0].date).toISOString().split("T")[0];
+  const newestPostOriginalDate = formatDate(allPosts[0].date);
 
-  const tagPages = getAllTags(allPosts)
-    .map((tag) => {
-      const tagSlug = slugifyTag(tag);
-      const tagPosts = allPosts.filter((p) => p.tags?.some((t) => slugifyTag(t) === tagSlug));
-      if (tagPosts.length < 4) return null;
-      const lastmod = new Date(tagPosts[0].last_updated || tagPosts[0].date)
-        .toISOString()
-        .split("T")[0];
-      return { path: `/blog/tag/${tagSlug}`, priority: "0.6", changefreq: "weekly", lastmod };
-    })
-    .filter(Boolean) as SitemapPage[];
+  const tagPages = _tagSitemapPages(allPosts);
 
   const allPages = [
     ..._staticPages.map((p) => {

--- a/apps/frontend/src/tests/fixtures/posts.ts
+++ b/apps/frontend/src/tests/fixtures/posts.ts
@@ -1,0 +1,26 @@
+import type { BlogPostMeta } from "$lib/blog";
+
+export const makePost = (overrides: Partial<BlogPostMeta> & { slug: string }): BlogPostMeta => ({
+  title: overrides.slug,
+  description: overrides.slug,
+  date: "2026-01-01",
+  readingTime: 1,
+  ...overrides,
+});
+
+/**
+ * `count` posts tagged `tag`, newest first — the order getAllPosts() returns.
+ * `tagsFor` overrides the raw tag strings per post, for slug-normalization cases.
+ */
+export const postsTagged = (
+  tag: string,
+  count: number,
+  tagsFor: (i: number) => string[] = () => [tag],
+): BlogPostMeta[] =>
+  Array.from({ length: count }, (_, i) =>
+    makePost({
+      slug: `${tag}-${i}`,
+      tags: tagsFor(i),
+      date: `2026-01-${String(count - i).padStart(2, "0")}`,
+    }),
+  );

--- a/apps/frontend/src/tests/sitemap.xml/tagPages.test.ts
+++ b/apps/frontend/src/tests/sitemap.xml/tagPages.test.ts
@@ -1,0 +1,39 @@
+import { TAG_INDEX_MIN_POSTS } from "$lib/blog";
+import { ROBOTS } from "$lib/seo";
+import { describe, expect, it } from "bun:test";
+
+import { loadTagListing } from "../../routes/blog/tag/[tag]/listing";
+import { _tagSitemapPages } from "../../routes/sitemap.xml/+server";
+import { makePost, postsTagged } from "../fixtures/posts";
+
+describe("_tagSitemapPages", () => {
+  it("emits one entry for raw tags that share a slug", () => {
+    const posts = postsTagged("google-cloud", TAG_INDEX_MIN_POSTS, (i) =>
+      i % 2 === 0 ? ["Google Cloud"] : ["google-cloud"],
+    );
+    expect(_tagSitemapPages(posts).map((p) => p.path)).toEqual(["/blog/tag/google-cloud"]);
+  });
+
+  it("never emits a bare /blog/tag/ for punctuation-only tags", () => {
+    const posts = postsTagged("vite", TAG_INDEX_MIN_POSTS, () => ["+++", "vite"]);
+    expect(_tagSitemapPages(posts).map((p) => p.path)).toEqual(["/blog/tag/vite"]);
+  });
+
+  it("takes lastmod from the newest post, preferring last_updated", () => {
+    const posts = postsTagged("vite", TAG_INDEX_MIN_POSTS);
+    posts[0] = makePost({ ...posts[0], last_updated: "2026-06-15" });
+    expect(_tagSitemapPages(posts)[0].lastmod).toBe("2026-06-15");
+  });
+});
+
+// Sitemap membership and the emitted robots directive read the same threshold via
+// isTagIndexable. This pins them to one verdict so a change can't move only one.
+describe("tag indexing threshold", () => {
+  for (const count of [0, TAG_INDEX_MIN_POSTS - 1, TAG_INDEX_MIN_POSTS, TAG_INDEX_MIN_POSTS + 1]) {
+    it(`agrees between sitemap and robots meta for ${count} posts`, () => {
+      const posts = postsTagged("vite", count);
+      const inSitemap = _tagSitemapPages(posts).some((p) => p.path === "/blog/tag/vite");
+      expect(inSitemap).toBe(loadTagListing("vite", 1, posts).robots === ROBOTS.default);
+    });
+  }
+});

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -1,11 +1,31 @@
 import adapter from "@sveltejs/adapter-cloudflare";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { mdsvex, escapeSvelte } from "mdsvex";
+import { execSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHighlighter } from "shiki";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// SvelteKit defaults version.name to Date.now(), which lands in the client runtime chunk
+// and re-hashes every chunk importing it — so every build busts the immutable asset cache
+// even when nothing changed. Git tree hashes of the inputs that can alter this bundle keep
+// it stable across deploys that don't touch them. `HEAD:path` is repo-root relative.
+const appVersion = () => {
+  try {
+    return execSync("git rev-parse HEAD:apps/frontend HEAD:bun.lock", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim()
+      .split("\n")
+      .map((sha) => sha.slice(0, 12))
+      .join("-");
+  } catch {
+    return process.env.GITHUB_SHA ?? "dev";
+  }
+};
 
 const shikiHighlighter = await createHighlighter({
   themes: ["github-dark"],
@@ -41,6 +61,7 @@ const config = {
   kit: {
     adapter: adapter(),
     inlineStyleThreshold: Infinity,
+    version: { name: appVersion() },
     prerender: {
       handleUnseenRoutes: ({ routes, message }) => {
         // Pagination routes legitimately produce zero pages until the post


### PR DESCRIPTION
Started from a question — does the sitemap use the same rule as `noIndex` for tag pages? — and the answer was "same value, by coincidence." Fixing that properly turned up two adjacent problems in the same area.

## Tag indexing was decided twice

The threshold `4` was written three times as a bare literal (sitemap endpoint, both tag page components) with two hand-written copies of the counting predicate, in files that never imported each other. Same verdict today, but editing one would silently desync sitemap membership from the emitted `robots` directive.

The gate now lives once in `$lib/blog` — `TAG_INDEX_MIN_POSTS`, `getPostsForTag`, `isTagIndexable`. `loadTagListing` derives the directive and the sitemap filters on the same predicate. `isTagIndexable` takes the filtered posts rather than a bare count, so *what counts* can't drift either. A test feeds one fixture into both sides at 0/3/4/5 posts and asserts they agree.

Two normalization bugs fell out of the same duplication:

- `getAllTags` deduped on `toLowerCase()` while all three callers immediately mapped through `slugifyTag`, so two raw tags collapsing to one slug (`"Google Cloud"` + `"google-cloud"`) could emit **duplicate `<loc>` entries**. Replaced with `getAllTagSlugs`, deduping in slug space and dropping tags that slugify to `""` (those produced a bare `/blog/tag/`).
- `loadTagListing` lowercased its param instead of slugifying it, so the two sides didn't agree on what identifies a tag.

## Robots directives are a policy, not two booleans

`noIndex` implied `nofollow` with no way to opt out, so thin tag listings were telling crawlers not to follow links to the posts they exist to list. Directives are now a `ROBOTS` policy in `$lib/seo`; thin listings emit `noindex, follow` and the two `+error` pages keep `noindex, nofollow`. Every other SEO prop already arrived as `data.*` from a load — policy now does too, instead of sitting as a literal in markup.

## Every post shipped in one chunk

Reading one post downloaded **all** post bodies: they were merged into a single 28.5 KB chunk that `/blog/[slug]` imported *statically*. `blog-loader.ts` globbed lazily and correctly — it was defeated one import up. `$lib/blog` held an eager `import.meta.glob`, and client code imported `slugFromPath`/`slugifyTag` from it; Vite hoists globs to top-level static imports regardless of sitting inside a function body, so one 2-line helper dragged in every post.

Post loading moved to `$lib/blog.server.ts`. The `.server` suffix makes SvelteKit fail the build on any client import — verified by temporarily importing it into `PostTags.svelte`, which errors with *"Cannot import $lib/blog.server.ts into code that runs in the browser"*. So this can't silently regress.

| | before | after |
|---|---|---|
| Hello World | ⎫ one shared chunk, **10.6 KB gz**, | 702 B gz |
| Flowtracing | ⎬ statically imported — every post | 5,341 B gz |
| Website Stack | ⎭ visit pulled all three | 4,838 B gz |

Also confirmed the `?raw` glob never reached the client (no markdown syntax in any chunk), so reading-time computation stays server-side.

## Builds weren't reproducible

Two builds of identical source produced different content hashes for **28 of 36** chunks — and `_app/immutable` is served `max-age=31536000`, so every deploy invalidated the entire bundle whether or not anything changed.

Bisected by normalizing chunk names away: exactly **one** chunk was genuinely non-deterministic, the other 27 differed only because their import specifiers pointed at it. Inside it:

```
var C = globalThis.__sveltekit_1m7haqj…   vs   __sveltekit_9mrtmn…
fe = `1785240049790`                      vs   `1785240055546`
```

That's `kit.version.name`, which SvelteKit defaults to `Date.now()`, plus the `__sveltekit_<hash>` global derived from it — in the client runtime chunk everything transitively imports. SvelteKit's docs require this value be deterministic; the default violates that. Now derived from git tree hashes of the inputs that can change this bundle:

| scenario | chunks re-hashed (of 36) |
|---|---|
| no-op rebuild — before | 28 |
| no-op rebuild — after | **0** (byte-identical) |
| edit one post | **3** |
| commit touching neither `apps/frontend` nor the lockfile | **0** |

So the per-post chunking above actually pays off: publishing a post leaves 33 of 36 chunks cached.

## Cleanups

The sitemap's new `lastmod` line was a fourth copy of `formatDate`'s body — all four now call it. The two tag components were byte-identical but for the title, so the title moved into the load and they share `TagListing.svelte`. `pageURL` is exported so `BlogPostList` stops reimplementing the `/page/N` shape (with `paginationURLs.test.ts` added, since single-page listings mean the nav never renders in the build). Dead `allSlugs`/`totalPosts` dropped from load payloads.

## Verification

`bun run lint`, `format:check`, `check:ci` (0 errors/0 warnings), `test:unit` (116 frontend + 19 backend), and `build` all pass. Test count went 90 → 116; three drifting local `post()` fixtures collapsed into `src/tests/fixtures/posts.ts`.

Checked against the real build output: sitemap unchanged at 8 URLs (0 tag — with 3 posts the largest tag has 2, so nothing clears the threshold and this is behaviour-neutral today), 12 tag pages still prerendered, thin tag page `noindex, follow` with canonical intact, `/blog` keeps the full rich directive, error pages still `noindex, nofollow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
