### PR TITLE
frontend: Fail the build rather than freeze the app version

### DIFF
--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -12,18 +12,35 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // and re-hashes every chunk importing it — so every build busts the immutable asset cache
 // even when nothing changed. Git tree hashes of the inputs that can alter this bundle keep
 // it stable across deploys that don't touch them. `HEAD:path` is repo-root relative.
+const treeVersion = () =>
+  execSync("git rev-parse HEAD:apps/frontend HEAD:bun.lock", {
+    stdio: ["ignore", "pipe", "ignore"],
+  })
+    .toString()
+    .trim()
+    .split("\n")
+    .map((sha) => sha.slice(0, 12))
+    .join("-");
+
+// Every build platform exposes the commit it is building. Less precise than the tree
+// hashes — any commit changes it — but still unique per deploy.
+const platformCommit = () =>
+  process.env.WORKERS_CI_COMMIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA ?? process.env.GITHUB_SHA;
+
+// Never fall back to a constant. SvelteKit compares this value to decide a new deployment
+// happened; freezing it silently disables that, and the failure only shows up as clients
+// holding a stale manifest. Failing the build is the lesser evil.
 const appVersion = () => {
   try {
-    return execSync("git rev-parse HEAD:apps/frontend HEAD:bun.lock", {
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .toString()
-      .trim()
-      .split("\n")
-      .map((sha) => sha.slice(0, 12))
-      .join("-");
+    return treeVersion();
   } catch {
-    return process.env.GITHUB_SHA ?? "dev";
+    const sha = platformCommit();
+    if (sha) return sha.slice(0, 12);
+    throw new Error(
+      "Cannot derive kit.version.name: no git repository, and no commit SHA in the " +
+        "environment (WORKERS_CI_COMMIT_SHA / CF_PAGES_COMMIT_SHA / GITHUB_SHA). Building " +
+        "with a constant version would silently break SvelteKit's new-deployment detection.",
+    );
   }
 };
 


### PR DESCRIPTION
Follow-up to #601, which merged before this landed — `main` currently has the fallback this fixes.

## First, the good news: the risk is not active

I flagged this as a live concern; the evidence says otherwise. Cloudflare Workers Builds exposes `_app/version.json`, so the deployed value can be read directly:

```
production                     {"version":"2ac0eadad43a-f07326f1c042"}
Workers Builds commit preview  {"version":"5ced3acebafa-f07326f1c042"}
```

Both are tree-hash pairs, not `"dev"` — so **git is available in Workers Builds** and the primary path already works. This PR is a guardrail against that changing, not a repair.

## The problem it guards against

`appVersion` fell back to the constant `"dev"` whenever git was unavailable *and* `GITHUB_SHA` was unset — which is every environment outside GitHub Actions, including Workers Builds, where this repo actually deploys from (the Actions deploy job is commented out).

A frozen version silently disables SvelteKit's new-deployment detection: the `updated` store never fires, and a client holding a stale manifest only recovers by 404ing on a removed chunk and falling back to a full reload. It degrades quietly, which is the worst failure mode for a cache-correctness mechanism — nothing breaks visibly, the guarantee just stops holding.

## The change

Git tree hashes stay the preferred source, since they're the only option stable across deploys that touch neither `apps/frontend` nor the lockfile. Failing that, any platform-provided commit SHA is at least unique per deploy — Workers Builds (`WORKERS_CI_COMMIT_SHA`), Pages (`CF_PAGES_COMMIT_SHA`) and Actions (`GITHUB_SHA`) all expose one. With neither available the build throws, naming the variables it looked for.

Shipping a constant is worse than not shipping.

## Verification

All four paths exercised by importing the config directly:

| condition | result |
|---|---|
| git available | `563d949d4daf-f07326f1c042` (tree hashes) |
| `GIT_DIR` broken + `WORKERS_CI_COMMIT_SHA` | `deadbeefcafe` |
| `GIT_DIR` broken + `GITHUB_SHA` | `abcdef123456` |
| `GIT_DIR` broken, no SHA anywhere | throws with the variable names |

`lint`, `format:check`, `check:ci` (0 errors/0 warnings), `test:unit` (116 frontend + 19 backend) and `build` all pass. No behaviour change on the happy path — the derived version is identical to what production already serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
