### PR TITLE
blog: Drop the Axion tag from the flowtracing post

### DIFF
--- a/apps/frontend/src/blog_posts/Flowtracing_Go_Brrrr.md
+++ b/apps/frontend/src/blog_posts/Flowtracing_Go_Brrrr.md
@@ -3,7 +3,7 @@ title: "Flowtracing Go Brrrr - Making our pipeline faster, cheaper and greener w
 date: 2026-07-20
 last_updated: 2026-07-20
 description: "How we made the flowtracing pipeline at Electricity Maps 30% faster with 46% less CPU time by switching to Google's ARM-based Axion (C4A) processors on Dataflow, and what it actually took to get there."
-tags: ["Google Cloud", "Dataflow", "ARM", "Axion", "Performance", "Sustainability"]
+tags: ["Google Cloud", "Dataflow", "ARM", "Performance", "Sustainability"]
 ---
 
 **TL;DR:** We switched the flowtracing pipeline at Electricity Maps from x86 workers to ARM-based C4A machines powered by Google's Axion processors. Wall time went down 30%, CPU time went down 46%, the machines are about 25% cheaper and, according to Google, up to 60% more energy efficient. Faster, cheaper and greener! Funny thing is, we didn't even have to change the pipeline code to do it.


### PR DESCRIPTION
Axion is specific enough that it will never reach the four posts needed to clear the tag-indexing threshold added in #601, so `/blog/tag/axion` would stay `noindex` indefinitely while still being linked from the post — a permanently thin collection page.

The topic stays covered by the **ARM** and **Google Cloud** tags, and Axion is still named in the post's title, description and prose. Only the frontmatter tag list changed.

Prerendered tag pages go 12 → 11:

```
arm blog cloudflare dataflow google-cloud mdsvex
performance sustainability sveltekit tailwindcss vite
```

The post now renders 5 tag links (`arm`, `dataflow`, `google-cloud`, `performance`, `sustainability`). Sitemap unchanged at 8 URLs, RSS unchanged. `test:unit` (116 frontend + 19 backend) and `build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)