### PR TITLE
frontend: Harden external links against reverse tabnabbing

### DIFF
--- a/apps/frontend/src/components/Link.svelte
+++ b/apps/frontend/src/components/Link.svelte
@@ -31,7 +31,11 @@
   {href}
   {target}
   {rel}
-  class={['inline-flex items-center gap-0.5', mono && 'font-mono', className]}
+  class={[
+    'inline-flex items-center gap-0.5 hover:text-accent transition-colors',
+    mono && 'font-mono',
+    className,
+  ]}
   {...restProps}
 >
   {@render children()}

--- a/apps/frontend/src/components/Link.svelte
+++ b/apps/frontend/src/components/Link.svelte
@@ -8,18 +8,29 @@
     mono = false,
     children,
     class: className = "",
+    rel: relProp,
+    target: targetProp,
     ...restProps
   }: HTMLAnchorAttributes & { mono?: boolean; children: Snippet } = $props();
 
   const isExternal = $derived(
     href?.startsWith("http://") || href?.startsWith("https://"),
   );
+
+  const target = $derived(targetProp ?? (isExternal ? "_blank" : undefined));
+
+  // Merged, not left to restProps, which spreads last and would replace it.
+  const rel = $derived(
+    [(isExternal || target === "_blank") && "noopener noreferrer", relProp]
+      .filter(Boolean)
+      .join(" ") || undefined,
+  );
 </script>
 
 <a
   {href}
-  target={isExternal ? "_blank" : undefined}
-  rel={isExternal ? "noopener noreferrer" : undefined}
+  {target}
+  {rel}
   class={['inline-flex items-center gap-0.5', mono && 'font-mono', className]}
   {...restProps}
 >


### PR DESCRIPTION
## Problem

`Link.svelte` spread `{...restProps}` **after** its computed `rel`, so any caller passing `rel` replaced `noopener noreferrer` outright.

This was live, not latent. `lib/mdsvex/layout.svelte` re-exports this component as the markdown anchor (`export { Link as a }`), and something in the markdown pipeline adds `rel="nofollow"` — so every external link in every blog post shipped `target="_blank"` with no tabnabbing protection.

Measured by building both ways and counting `rel` values across all prerendered pages:

| `rel` value | before | after |
| --- | --- | --- |
| `nofollow` (unhardened) | **33** | 0 |
| `license` (unhardened) | **22** | 0 |
| `noopener noreferrer` | 75 | 75 |
| `noopener noreferrer nofollow` | 0 | 33 |
| `noopener noreferrer license` | 0 | 22 |

**55 external links** were affected.

## Fix

`rel` and `target` are destructured out of `restProps` and merged rather than overwritten. `rel` keys off the *resolved* target, so an internal href given `target="_blank"` is hardened too — while an external link sent to `_self` keeps `noreferrer`, so no existing behaviour regresses.

The second commit moves `hover:text-accent transition-colors` into the base class; every call site wanted it, and blog prose links previously had no accent hover despite `theme.css` documenting accent as the token for content-link hovers.

## Verification

Swept all prerendered pages: **130 external anchors, 0 missing `noopener`/`noreferrer`, 0 `target="_blank"` unhardened, 0 empty `rel=""`, 0 internal same-tab links wrongly hardened.** oxfmt, oxlint, svelte-check (0/0), 116 tests, build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)