### PR TITLE
frontend: Read date constants in UTC and hoist them into $lib

### DIFF
--- a/apps/frontend/src/components/Timeline.svelte
+++ b/apps/frontend/src/components/Timeline.svelte
@@ -3,9 +3,9 @@
 	import type { TimelineMode } from './timeline/types';
 	import TimelineGraph from './timeline/TimelineGraph.svelte';
 	import TimelineAccordionCard from './timeline/TimelineAccordionCard.svelte';
+	import { CURRENT_YEAR } from '$lib/helpers/currentDate';
 	import {
 		ORIGIN_YEAR,
-		CURRENT_YEAR,
 		PX_PER_MONTH,
 		GRAPH_TOP_PADDING_PX
 	} from './timeline/constants';

--- a/apps/frontend/src/components/timeline/constants.ts
+++ b/apps/frontend/src/components/timeline/constants.ts
@@ -1,11 +1,10 @@
 import { timelineEntries } from "$data/metadata";
+import { CURRENT_YEAR, CURRENT_MONTH } from "$lib/helpers/currentDate";
 
 // Layout constants
 const lifeEntry = timelineEntries.find((e) => e.type === "life");
 export const ORIGIN_YEAR = lifeEntry?.startYear ?? 1999;
 export const ORIGIN_MONTH = lifeEntry?.startMonth ?? 1;
-export const CURRENT_YEAR = new Date().getFullYear();
-export const CURRENT_MONTH = new Date().getMonth() + 1;
 const PX_PER_YEAR = 96;
 export const PX_PER_MONTH = PX_PER_YEAR / 12;
 export const TOTAL_MONTHS = (CURRENT_YEAR - ORIGIN_YEAR) * 12 + CURRENT_MONTH;

--- a/apps/frontend/src/components/timeline/types.test.ts
+++ b/apps/frontend/src/components/timeline/types.test.ts
@@ -74,7 +74,9 @@ describe("entryEndAbsMonth", () => {
       endYear: null,
     } as TimelineEntry;
     const now = new Date();
-    expect(entryEndAbsMonth(entry)).toBe(toAbsoluteMonth(now.getFullYear(), now.getMonth() + 1));
+    expect(entryEndAbsMonth(entry)).toBe(
+      toAbsoluteMonth(now.getUTCFullYear(), now.getUTCMonth() + 1),
+    );
   });
 
   it("falls back to start date when endYear is undefined", () => {

--- a/apps/frontend/src/components/timeline/types.ts
+++ b/apps/frontend/src/components/timeline/types.ts
@@ -1,12 +1,12 @@
 import type { TimelineEntry } from "$interfaces/timelineEntry";
 
+import { CURRENT_YEAR, CURRENT_MONTH } from "$lib/helpers/currentDate";
+
 import {
   ORIGIN_YEAR,
   ORIGIN_MONTH,
   TOTAL_MONTHS,
   PX_PER_MONTH,
-  CURRENT_YEAR,
-  CURRENT_MONTH,
   GRAPH_TOP_PADDING_PX,
 } from "./constants";
 

--- a/apps/frontend/src/lib/helpers/currentDate.ts
+++ b/apps/frontend/src/lib/helpers/currentDate.ts
@@ -1,5 +1,5 @@
-// Read from a single Date instance.
+// UTC, read from a single Date instance.
 const now = new Date();
 
-export const CURRENT_YEAR = now.getFullYear();
-export const CURRENT_MONTH = now.getMonth() + 1;
+export const CURRENT_YEAR = now.getUTCFullYear();
+export const CURRENT_MONTH = now.getUTCMonth() + 1;

--- a/apps/frontend/src/lib/helpers/currentDate.ts
+++ b/apps/frontend/src/lib/helpers/currentDate.ts
@@ -1,0 +1,5 @@
+// Read from a single Date instance.
+const now = new Date();
+
+export const CURRENT_YEAR = now.getFullYear();
+export const CURRENT_MONTH = now.getMonth() + 1;

--- a/apps/frontend/src/tests/setup.ts
+++ b/apps/frontend/src/tests/setup.ts
@@ -1,7 +1,7 @@
 import { setSystemTime } from "bun:test";
 
-// Freeze time before any module loads so date-derived constants (e.g. the
-// timeline's CURRENT_YEAR/CURRENT_MONTH, computed at import time) and their
-// snapshots stay stable as real time moves on.
+// Freeze time before any module loads so date-derived constants (CURRENT_YEAR
+// and CURRENT_MONTH in $lib/helpers/currentDate, computed at import time) and
+// their snapshots stay stable as real time moves on.
 // Bump this date together with any affected snapshots.
 setSystemTime(new Date("2026-04-01T00:00:00Z"));


### PR DESCRIPTION
## Problem

`CURRENT_YEAR` / `CURRENT_MONTH` used `getFullYear()` / `getMonth()`, which read the **host timezone**. `src/tests/setup.ts` freezes the clock at `2026-04-01T00:00:00Z`, which resolves to **March** for anyone west of UTC — so the timeline snapshot failed on a clean checkout:

```
TZ=UTC                    6 pass  0 fail
TZ=America/Los_Angeles    5 pass  1 fail   ← CURRENT_MONTH = 3, not 4
```

Any contributor or CI runner in a negative-UTC-offset zone got a red `bun run test:unit`.

## Changes

1. **Hoist** the two constants out of `components/timeline/constants.ts` into `$lib/helpers/currentDate.ts`. The old home imports `$data/metadata`, so anything outside the timeline that wanted them would have pulled the timeline graph into its chunk. Also reads from a **single** `Date` so year and month cannot come from two different instants.
2. **Read them in UTC.** `types.test.ts` also derived its own expectation from local time, so that moved to UTC as well.

## Verification

Full suite across eight zones spanning UTC−11 to UTC+14 plus a half-hour offset — UTC, America/Los_Angeles, America/New_York, Pacific/Midway, Pacific/Kiritimati, Asia/Tokyo, Asia/Kathmandu, Europe/Stockholm — **116 pass / 0 fail in every one.**

Snapshots are unchanged: UTC under the frozen clock yields the same values they were recorded with.

I also confirmed the hoist keeps the timeline metadata out of the root-layout chunk by walking the built chunk graph — timeline data stays in the `/history` node only.

> Base of a stack: #609 (footer) targets this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)