### PR TITLE
frontend: Modulepreload the entry chunks

### DIFF
--- a/apps/frontend/src/hooks.server.ts
+++ b/apps/frontend/src/hooks.server.ts
@@ -4,7 +4,8 @@ import { ifNoneMatchHits, weakEtag } from "$lib/helpers/etag";
 
 export const handle: Handle = async ({ event, resolve }) => {
   const response = await resolve(event, {
-    preload: ({ type }) => type === "css" || type === "font",
+    preload: ({ type, path }) =>
+      type === "css" || type === "font" || (type === "js" && path.includes("/entry/")),
   });
 
   // Add an ETag to SSR HTML responses and return 304 when If-None-Match matches.


### PR DESCRIPTION
## Problem

The `preload` filter in `hooks.server.ts` excluded JS entirely, so `start.js` and `app.js` were only discovered once the inline bootstrap script **executed**. A Lighthouse trace showed the cost:

```
viktor.andersson.tech          107 ms   10.07 KiB
  entry/start.js               243 ms
  entry/app.js                 245 ms
    chunks/4JeiHPYu.js         332 ms
      chunks/DuqgYnXA.js       393 ms
        chunks/BnHBkSot.js     502 ms    0.95 KiB   ← critical chain leaf
```

The leaf is under 1 KiB but lands at 502 ms — the cost is four sequential levels of *discovery*, not bytes.

## Change

Preload the two entry chunks so the browser fetches them from the HTML parse instead of after script execution. Everything downstream shifts earlier.

**Cost: +7 bytes of brotli'd HTML** (+152 raw).

## Why only the entries

`modulepreload` is **high priority** and competes with fonts and the LCP element. Preloading all 17 chunks costs +200 B brotli and is what regressed LCP in c5c6d14, which is why JS was dropped from the filter in the first place. The two entry chunks are different: they are unconditionally needed on every page, so they are not extra work — just earlier.

If we later want the rest, the safer shape is the one 9714d33 deleted: `modulepreload` the entries, `rel="prefetch"` (low priority) the rest.

## Note

I could not measure LCP locally — worth re-running Lighthouse on the deployed branch to confirm no regression before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)