### PR TITLE
frontend: Add a shell-style site footer

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -33,17 +33,26 @@
 
 /* Custom utilities */
 
+/* The shared content column width, used by <main>'s pages, the nav and the footer. */
+@utility page-width {
+  max-width: 56rem;
+  margin-inline: auto;
+  width: 100%;
+}
+
 @utility page-container {
+  @apply page-width;
   display: flex;
   flex-direction: column;
   gap: 2rem;
   justify-content: flex-start;
   padding-top: 2rem;
   align-items: center;
-  max-width: 56rem;
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
+}
+
+/* Horizontal page gutters for <main> and the footer. Zero at lg. */
+@utility page-gutters {
+  @apply px-4 md:px-8 lg:px-0;
 }
 
 /* Frosted "glass pill" surface shared by the nav, mobile menu, skip link

--- a/apps/frontend/src/components/Footer.svelte
+++ b/apps/frontend/src/components/Footer.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { version } from "$app/environment";
+  import Highlight from "$components/Highlight.svelte";
+  import Link from "$components/Link.svelte";
+  import { LICENSE_URL, SOCIAL_LINKS } from "$lib/config";
+  import { CURRENT_YEAR } from "$lib/helpers/currentDate";
+
+  // First 8 chars of kit.version.name — see appVersion() in svelte.config.js.
+  const build = version.slice(0, 8);
+</script>
+
+{#snippet prompt(command: string)}
+  <span class="text-surface-300" aria-hidden="true"><Highlight>~</Highlight> $ {command}</span>
+{/snippet}
+
+<footer class="w-full page-gutters mt-8 mb-2">
+  <div class="page-width flex flex-col gap-4 font-mono text-sm">
+    <hr class="border-surface-700" />
+
+    <div class="flex flex-col gap-1">
+      {@render prompt("ls elsewhere/")}
+      <ul class="flex flex-wrap gap-x-6 gap-y-1">
+        {#each SOCIAL_LINKS as social}
+          <li>
+            <Link href={social.href} class="text-surface-100">{social.label}</Link>
+          </li>
+        {/each}
+      </ul>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      {@render prompt("cat LICENSE")}
+      <p class="flex flex-wrap items-center gap-x-2 text-surface-100">
+        <span>
+          <Link href={LICENSE_URL} rel="license" aria-label="MIT license">MIT</Link>
+          &copy; {CURRENT_YEAR} Viktor Andersson
+        </span>
+        <span class="text-surface-300 whitespace-nowrap">
+          <span class="sr-only">Build</span>
+          <span aria-hidden="true">#</span>
+          {build}
+        </span>
+      </p>
+    </div>
+  </div>
+</footer>

--- a/apps/frontend/src/components/ProfileCard.svelte
+++ b/apps/frontend/src/components/ProfileCard.svelte
@@ -2,6 +2,7 @@
   // @ts-expect-error — Vite enhanced:img query string not resolvable by svelte-check
   import portrait from "$images/Viktor_Andersson.jpeg?w=96;192&enhanced";
   import Link from "$components/Link.svelte";
+  import { SOCIAL_LINKS } from "$lib/config";
 
   let { as = "h2" }: { as?: "h1" | "h2" } = $props();
 </script>
@@ -18,8 +19,9 @@
     <p class="text-base text-surface-300">Software Engineer</p>
     <p class="text-sm text-surface-400">Malmö, Sweden</p>
     <div class="flex flex-wrap gap-4 text-sm mt-1">
-      <Link href="https://www.linkedin.com/in/viktor-va-andersson/" mono>open linkedin</Link>
-      <Link href="https://github.com/viktorvav99" mono>open github</Link>
+      {#each SOCIAL_LINKS as social}
+        <Link href={social.href} mono>{social.label}</Link>
+      {/each}
     </div>
   </div>
 </div>

--- a/apps/frontend/src/lib/config.ts
+++ b/apps/frontend/src/lib/config.ts
@@ -9,6 +9,27 @@ export const SITE_DESCRIPTION =
 /** Blog section description, shared by the listing pages, RSS channel, and llms.txt. */
 export const BLOG_DESCRIPTION = "Thoughts on software engineering, climate tech, and open source";
 
+export const REPO_URL = "https://github.com/VIKTORVAV99/personal-website";
+
+/** Also hardcoded in app.html's `<link rel="license">`, which cannot import. */
+export const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
+
+/**
+ * Profile links, shared by the footer, ProfileCard, and the Person schema's sameAs.
+ * Labels are the link text everywhere, so the same destination reads the same in both places.
+ */
+export const SOCIAL_LINKS = [
+  { label: "github", href: "https://github.com/viktorvav99" },
+  { label: "linkedin", href: "https://www.linkedin.com/in/viktor-va-andersson/" },
+  { label: "bluesky", href: "https://bsky.app/profile/viktor.andersson.tech" },
+] as const;
+
+/** Identity URLs added to the Person schema's sameAs only, never rendered as links. */
+export const IDENTITY_URLS: readonly string[] = [
+  "https://dev.to/viktorvav99",
+  "https://x.com/VIKTORVAV99",
+];
+
 // Social scrapers (Open Graph, Twitter Cards) and Google's structured-data
 // parser require absolute image URLs, so prefix the Vite asset path.
 export const FALLBACK_HERO_IMAGE = `${SITE_URL}${FallbackHeroImage}`;

--- a/apps/frontend/src/lib/seo/person.ts
+++ b/apps/frontend/src/lib/seo/person.ts
@@ -1,5 +1,5 @@
 import portrait from "$images/Viktor_Andersson.jpeg";
-import { SITE_URL } from "$lib/config";
+import { IDENTITY_URLS, SITE_URL, SOCIAL_LINKS } from "$lib/config";
 import {
   createPersonSchema,
   createOrganizationSchema,
@@ -33,7 +33,7 @@ const hh = createCollegeOrUniversitySchema({
 });
 
 export const PROFILE_DATE_CREATED = new Date("2026-03-20").toISOString();
-export const PROFILE_DATE_MODIFIED = new Date("2026-07-18").toISOString();
+export const PROFILE_DATE_MODIFIED = new Date("2026-07-29").toISOString();
 
 export const siteOwnerPerson = createPersonSchema({
   "@id": `${SITE_URL}/#person`,
@@ -94,9 +94,5 @@ export const siteOwnerPerson = createPersonSchema({
       }),
     }),
   ],
-  sameAs: [
-    "https://github.com/viktorvav99",
-    "https://www.linkedin.com/in/viktor-va-andersson/",
-    "https://bsky.app/profile/viktor.andersson.tech",
-  ],
+  sameAs: [...SOCIAL_LINKS.map((social) => social.href), ...IDENTITY_URLS],
 });

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import Menu from "@lucide/svelte/icons/menu";
   import { afterNavigate } from "$app/navigation";
   import { page, navigating } from "$app/state";
+  import Footer from "$components/Footer.svelte";
   import Highlight from "$components/Highlight.svelte";
   import { SITE_URL } from "$lib/config";
   import { SITE_PAGES } from "$lib/pages";
@@ -23,7 +24,6 @@
 
   let open = $state(false);
   let mobileMenu = $state<HTMLDetailsElement>();
-  const year = $derived(new Date().getFullYear());
 
   let { children }: { children: Snippet } = $props();
 
@@ -119,7 +119,7 @@
     <!-- Desktop nav -->
     <nav
       aria-label="Main"
-      class="hidden md:flex font-mono w-full max-w-4xl mx-auto justify-evenly items-center gap-4 lg:gap-8 py-4 px-4 lg:px-8 rounded-full glass-surface"
+      class="hidden md:flex font-mono page-width justify-evenly items-center gap-4 lg:gap-8 py-4 px-4 lg:px-8 rounded-full glass-surface"
     >
       {@render navbarLinks()}
     </nav>
@@ -141,21 +141,11 @@
   </header>
   <!-- #endregion -->
   <!-- #region Main -->
-  <main id="main-content" tabindex="-1" class="flex-1 flex px-4 md:px-8 lg:px-0 flex-col outline-none">
+  <main id="main-content" tabindex="-1" class="flex-1 flex page-gutters flex-col outline-none">
     {@render children()}
   </main>
   <!-- #endregion -->
-  <!-- #region Footer -->
-  <footer class="flex flex-col w-full mt-8 mb-2 justify-center items-center">
-    <small>{year} &copy; Viktor Andersson </small>
-    <small
-      >Source code licensed under <a
-        href="https://github.com/VIKTORVAV99/personal-website/blob/main/LICENSE"
-        rel="license">MIT license</a
-      ></small
-    >
-  </footer>
-  <!-- #endregion -->
+  <Footer />
 
 <style>
   .nav-progress {

--- a/apps/frontend/src/routes/+page.server.ts
+++ b/apps/frontend/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import { getAllPosts } from "$lib/blog.server";
-import { SITE_URL, SITE_DESCRIPTION } from "$lib/config";
+import { SITE_URL, SITE_DESCRIPTION, REPO_URL, LICENSE_URL } from "$lib/config";
 import {
   createWebSiteSchema,
   createSoftwareSourceCodeSchema,
@@ -22,10 +22,10 @@ const structuredData = [
   siteOwnerPerson,
   createSoftwareSourceCodeSchema({
     name: "personal-website",
-    codeRepository: "https://github.com/VIKTORVAV99/personal-website",
+    codeRepository: REPO_URL,
     programmingLanguage: ["TypeScript", "Svelte"],
     author: SITE_OWNER_PERSON_REF,
-    license: "https://github.com/VIKTORVAV99/personal-website/blob/main/LICENSE",
+    license: LICENSE_URL,
   }),
 ];
 

--- a/apps/frontend/src/tests/appHtml.test.ts
+++ b/apps/frontend/src/tests/appHtml.test.ts
@@ -1,0 +1,23 @@
+import { LICENSE_URL, SITE_URL } from "$lib/config";
+import { describe, it, expect } from "bun:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appHtml = await Bun.file(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../app.html"),
+).text();
+
+describe("app.html", () => {
+  // app.html is a static template and cannot import from $lib, so these
+  // literals are the one place the constants are duplicated.
+  it("declares the same license URL as LICENSE_URL", () => {
+    const href = appHtml.match(/<link\s+rel="license"\s+href="([^"]+)"/)?.[1];
+    expect(href).toBe(LICENSE_URL);
+  });
+
+  it("hardcodes no other absolute URL to the site or repo", () => {
+    const urls = [...appHtml.matchAll(/https?:\/\/[^"'\s>]+/g)].map((m) => m[0]);
+    const unexpected = urls.filter((u) => u !== LICENSE_URL && !u.startsWith(SITE_URL));
+    expect(unexpected).toEqual([]);
+  });
+});

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -27,6 +27,7 @@ const treeVersion = () =>
 const platformCommit = () =>
   process.env.WORKERS_CI_COMMIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA ?? process.env.GITHUB_SHA;
 
+// The footer displays the first 8 characters of this value.
 // Never fall back to a constant. SvelteKit compares this value to decide a new deployment
 // happened; freezing it silently disables that, and the failure only shows up as clients
 // holding a stale manifest. Failing the build is the lesser evil.


### PR DESCRIPTION
> **Stacked on #606** — review only this branch's three commits; GitHub shows the incremental diff. Merge #606 first.

## Problem

The existing footer was two bare `<small>` elements with three defects independent of any redesign:

- **Misaligned** — no `max-w-4xl` and no gutters, so it centred full-bleed while the nav and every page aligned to 56rem. The only chrome that didn't line up.
- **Raw `<a>`** instead of `Link` — no `target`/`rel`, and it inherited the global `a:hover { underline }`.
- **Rendered in Inter** — the only site chrome not in Monaspace.

It also surfaced nothing: Bluesky existed in `person.ts`'s `sameAs` but was never rendered anywhere.

## Changes

**1. Consolidate links into `$lib/config`.** The repo URL was written out four times and the profile links three, with `ProfileCard` hardcoding two inline. `REPO_URL`, `LICENSE_URL` and `SOCIAL_LINKS` own them now; `IDENTITY_URLS` carries profiles that belong in `sameAs` but aren't linked from a page. `PROFILE_DATE_MODIFIED` is bumped because `sameAs` changed — it feeds the ProfilePage `dateModified` **and** the sitemap `lastmod` for `/about` and `/history`, which would otherwise tell crawlers the pages were untouched.

**2. `page-width` / `page-gutters` utilities.** The 56rem cap was spelled three times and the `px-4 md:px-8 lg:px-0` triple twice. A hand-copied three-breakpoint responsive triple is exactly what drifts silently.

**3. The footer.** Reads as a short shell session, continuing the `cd ~/blog` nav and the file-tree homepage:

```
────────────────────────────────────────
~ $ ls elsewhere/
github ↗   linkedin ↗   bluesky ↗

~ $ cat LICENSE
MIT ↗ © 2026 Viktor Andersson   # bf1a4b8c
```

## Accessibility

Command lines are `aria-hidden` decoration. Two things that needed care:

- The licence link's accessible name would otherwise be the bare word **"MIT"**, since its only context is a hidden prompt — it carries `aria-label="MIT license"`, which keeps the visible text a substring (WCAG 2.5.3).
- The build stamp has an **sr-only "Build" label rather than being hidden**. Hiding it was the obvious move, but it is exactly what a screen-reader user would quote in a bug report, so suppressing it would withhold information sighted users get.

All footer text clears WCAG AA: `surface-300` at 8.41:1 and `surface-100` at 12.99:1 on the `#111111` background.

## Verification

svelte-check 0 errors / 0 warnings across 4275 files, 118 tests, oxfmt, oxlint, build clean. `@apply` of a custom utility inside another `@utility` was the risky part of the `page-width` extraction — verified in the compiled CSS that `.page-container` still emits `max-width:56rem;margin-inline:auto;width:100%`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)