### PR TITLE
frontend: Single-source the author name and reorder page titles

### DIFF
--- a/apps/frontend/src/components/Footer.svelte
+++ b/apps/frontend/src/components/Footer.svelte
@@ -2,7 +2,7 @@
   import { version } from "$app/environment";
   import Highlight from "$components/Highlight.svelte";
   import Link from "$components/Link.svelte";
-  import { LICENSE_URL, SOCIAL_LINKS } from "$lib/config";
+  import { LICENSE_URL, SITE_AUTHOR, SOCIAL_LINKS } from "$lib/config";
   import { CURRENT_YEAR } from "$lib/helpers/currentDate";
 
   // First 8 chars of kit.version.name — see appVersion() in svelte.config.js.
@@ -33,7 +33,7 @@
       <p class="flex flex-wrap items-center gap-x-2 text-surface-100">
         <span>
           <Link href={LICENSE_URL} rel="license" aria-label="MIT license">MIT</Link>
-          &copy; {CURRENT_YEAR} Viktor Andersson
+          &copy; {CURRENT_YEAR} {SITE_AUTHOR}
         </span>
         <span class="text-surface-300 whitespace-nowrap">
           <span class="sr-only">Build</span>

--- a/apps/frontend/src/components/ProfileCard.svelte
+++ b/apps/frontend/src/components/ProfileCard.svelte
@@ -2,7 +2,7 @@
   // @ts-expect-error — Vite enhanced:img query string not resolvable by svelte-check
   import portrait from "$images/Viktor_Andersson.jpeg?w=96;192&enhanced";
   import Link from "$components/Link.svelte";
-  import { SOCIAL_LINKS } from "$lib/config";
+  import { SITE_AUTHOR, SOCIAL_LINKS } from "$lib/config";
 
   let { as = "h2" }: { as?: "h1" | "h2" } = $props();
 </script>
@@ -10,12 +10,12 @@
 <div class="flex gap-8 items-center w-full">
   <enhanced:img
     src={portrait}
-    alt="Portrait of Viktor Andersson"
+    alt={`Portrait of ${SITE_AUTHOR}`}
     class="rounded-full w-24 h-24 min-w-24 min-h-24 object-cover"
     fetchpriority="high"
   />
   <div class="flex flex-col gap-0.5">
-    <svelte:element this={as} class="text-2xl">Viktor Andersson</svelte:element>
+    <svelte:element this={as} class="text-2xl">{SITE_AUTHOR}</svelte:element>
     <p class="text-base text-surface-300">Software Engineer</p>
     <p class="text-sm text-surface-400">Malmö, Sweden</p>
     <div class="flex flex-wrap gap-4 text-sm mt-1">

--- a/apps/frontend/src/components/blog/AuthorBanner.svelte
+++ b/apps/frontend/src/components/blog/AuthorBanner.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   // @ts-expect-error — Vite enhanced:img query string not resolvable by svelte-check
   import portrait from "$images/Viktor_Andersson.jpeg?w=40;80&enhanced";
+  import { SITE_AUTHOR } from "$lib/config";
 </script>
 
 <hr class="border-surface-700" />
 <div class="flex items-center gap-3">
   <enhanced:img
     src={portrait}
-    alt="Portrait of Viktor Andersson"
+    alt={`Portrait of ${SITE_AUTHOR}`}
     class="rounded-full w-10 h-10 object-cover"
     fetchpriority="high"
   />
-  <a href="/" class="text-base text-surface-100 hover:text-accent transition-colors font-medium">Viktor Andersson</a>
+  <a href="/" class="text-base text-surface-100 hover:text-accent transition-colors font-medium">{SITE_AUTHOR}</a>
 </div>
 <hr class="border-surface-700" />

--- a/apps/frontend/src/lib/config.ts
+++ b/apps/frontend/src/lib/config.ts
@@ -3,8 +3,11 @@ import FallbackHeroImage from "$lib/assets/hero_banner.svg?w=1200&h=675&format=j
 
 export const SITE_URL = "https://viktor.andersson.tech";
 
-export const SITE_DESCRIPTION =
-  "Personal website for Viktor Andersson, Software Engineer at Electricity Maps and Digital Design and Innovation graduate";
+export const AUTHOR_GIVEN_NAME = "Viktor";
+export const AUTHOR_FAMILY_NAME = "Andersson";
+export const SITE_AUTHOR = `${AUTHOR_GIVEN_NAME} ${AUTHOR_FAMILY_NAME}`;
+
+export const SITE_DESCRIPTION = `Personal website for ${SITE_AUTHOR}, Software Engineer at Electricity Maps and Digital Design and Innovation graduate`;
 
 /** Blog section description, shared by the listing pages, RSS channel, and llms.txt. */
 export const BLOG_DESCRIPTION = "Thoughts on software engineering, climate tech, and open source";

--- a/apps/frontend/src/lib/helpers/pageTitle.test.ts
+++ b/apps/frontend/src/lib/helpers/pageTitle.test.ts
@@ -1,0 +1,18 @@
+import { SITE_AUTHOR } from "$lib/config";
+import { describe, it, expect } from "bun:test";
+
+import { pageTitle } from "./pageTitle";
+
+describe("pageTitle", () => {
+  it("puts the section first, separated by a pipe", () => {
+    expect(pageTitle("About")).toBe("About | Viktor Andersson");
+  });
+
+  it("returns the bare author when no section is given", () => {
+    expect(pageTitle()).toBe(SITE_AUTHOR);
+  });
+
+  it("reads the same for a post title as for a section", () => {
+    expect(pageTitle("A post about Svelte")).toBe("A post about Svelte | Viktor Andersson");
+  });
+});

--- a/apps/frontend/src/lib/helpers/pageTitle.ts
+++ b/apps/frontend/src/lib/helpers/pageTitle.ts
@@ -1,0 +1,5 @@
+import { SITE_AUTHOR } from "$lib/config";
+
+/** `<section> | <author>`; the bare author when no section is given. */
+export const pageTitle = (section?: string) =>
+  section ? `${section} | ${SITE_AUTHOR}` : SITE_AUTHOR;

--- a/apps/frontend/src/lib/seo/components/SEO.svelte
+++ b/apps/frontend/src/lib/seo/components/SEO.svelte
@@ -5,6 +5,9 @@
     FALLBACK_HERO_IMAGE_HEIGHT,
     FALLBACK_HERO_IMAGE_WIDTH,
     SITE_URL,
+    AUTHOR_FAMILY_NAME,
+    AUTHOR_GIVEN_NAME,
+    SITE_AUTHOR,
   } from "$lib/config";
   import type { Robots, StructuredDataSchema } from "..";
   import { ROBOTS, toJsonLd } from "..";
@@ -68,7 +71,7 @@
     {@html `<script type="application/ld+json">${toJsonLd(structuredData)}<` + `/script>`}
   {/if}
 
-  <meta property="og:site_name" content="Viktor Andersson" />
+  <meta property="og:site_name" content={SITE_AUTHOR} />
   <meta property="og:locale" content="en_US" />
   <meta property="og:type" content={type} />
   <meta property="og:title" content={title} />
@@ -82,8 +85,8 @@
       <meta property="article:tag" content={tag} />
     {/each}
   {:else if type === "profile"}
-    <meta property="profile:first_name" content="Viktor" />
-    <meta property="profile:last_name" content="Andersson" />
+    <meta property="profile:first_name" content={AUTHOR_GIVEN_NAME} />
+    <meta property="profile:last_name" content={AUTHOR_FAMILY_NAME} />
   {/if}
 
   {#if image}

--- a/apps/frontend/src/lib/seo/index.ts
+++ b/apps/frontend/src/lib/seo/index.ts
@@ -1,4 +1,4 @@
-import { SITE_URL } from "$lib/config";
+import { SITE_AUTHOR, SITE_URL } from "$lib/config";
 
 /** robots directives, one per indexing policy. Pages pick a policy; they never spell out directives. */
 export const ROBOTS = {
@@ -195,7 +195,7 @@ export const createPersonSchema = (options: Omit<PersonSchema, "@type">): Person
 
 export const SITE_OWNER_PERSON_REF = createPersonSchema({
   "@id": `${SITE_URL}/#person`,
-  name: "Viktor Andersson",
+  name: SITE_AUTHOR,
   url: SITE_URL,
 });
 

--- a/apps/frontend/src/lib/seo/person.ts
+++ b/apps/frontend/src/lib/seo/person.ts
@@ -1,5 +1,12 @@
 import portrait from "$images/Viktor_Andersson.jpeg";
-import { IDENTITY_URLS, SITE_URL, SOCIAL_LINKS } from "$lib/config";
+import {
+  AUTHOR_FAMILY_NAME,
+  AUTHOR_GIVEN_NAME,
+  IDENTITY_URLS,
+  SITE_AUTHOR,
+  SITE_URL,
+  SOCIAL_LINKS,
+} from "$lib/config";
 import {
   createPersonSchema,
   createOrganizationSchema,
@@ -37,9 +44,9 @@ export const PROFILE_DATE_MODIFIED = new Date("2026-07-29").toISOString();
 
 export const siteOwnerPerson = createPersonSchema({
   "@id": `${SITE_URL}/#person`,
-  name: "Viktor Andersson",
-  givenName: "Viktor",
-  familyName: "Andersson",
+  name: SITE_AUTHOR,
+  givenName: AUTHOR_GIVEN_NAME,
+  familyName: AUTHOR_FAMILY_NAME,
   url: SITE_URL,
   image: `${SITE_URL}${portrait}`,
   homeLocation: createPlaceSchema("Malmö", "SE"),

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
   import { page, navigating } from "$app/state";
   import Footer from "$components/Footer.svelte";
   import Highlight from "$components/Highlight.svelte";
-  import { SITE_URL } from "$lib/config";
+  import { SITE_AUTHOR, SITE_URL } from "$lib/config";
   import { SITE_PAGES } from "$lib/pages";
   import { type Snippet } from "svelte";
   import { motion } from "$lib/motion";
@@ -92,7 +92,7 @@
   <link
     rel="alternate"
     type="application/rss+xml"
-    title="Viktor Andersson"
+    title={SITE_AUTHOR}
     href={`${SITE_URL}/rss.xml`}
   />
 </svelte:head>

--- a/apps/frontend/src/routes/+page.server.ts
+++ b/apps/frontend/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import { getAllPosts } from "$lib/blog.server";
-import { SITE_URL, SITE_DESCRIPTION, REPO_URL, LICENSE_URL } from "$lib/config";
+import { SITE_URL, SITE_DESCRIPTION, SITE_AUTHOR, REPO_URL, LICENSE_URL } from "$lib/config";
 import {
   createWebSiteSchema,
   createSoftwareSourceCodeSchema,
@@ -13,7 +13,7 @@ import type { PageServerLoad } from "./$types";
 const structuredData = [
   createWebSiteSchema({
     "@id": SITE_WEBSITE_REF["@id"],
-    name: "Viktor Andersson",
+    name: SITE_AUTHOR,
     url: SITE_URL,
     description: SITE_DESCRIPTION,
     author: SITE_OWNER_PERSON_REF,

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import ProfileCard from "$components/ProfileCard.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
   import Highlight from "$components/Highlight.svelte";
-  import { SITE_DESCRIPTION } from "$lib/config";
+  import { SITE_AUTHOR, SITE_DESCRIPTION } from "$lib/config";
   import { SITE_PAGES } from "$lib/pages";
 
   let { data }: { data: PageData } = $props();
@@ -17,7 +17,7 @@
 {#snippet treeLink(href: string, label: string, prefix: string)}<a {href} class="flex items-center link-plain">{@render treeChar(prefix)}<span class="hover:underline underline-offset-4">{label}</span></a>{/snippet}
 
 <SEO
-  title="Viktor Andersson - Software Engineer"
+  title={`${SITE_AUTHOR} - Software Engineer`}
   description={SITE_DESCRIPTION}
   structuredData={data.structuredData}
 />

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -2,15 +2,15 @@
   import TitleText from "$components/TitleText.svelte";
   import ProfileCard from "$components/ProfileCard.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
-  import { SITE_URL } from "$lib/config";
+  import { SITE_AUTHOR, SITE_URL } from "$lib/config";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title="Viktor Andersson | About"
-  description="About Viktor Andersson, Software Engineer based in Malmö, Sweden, working at Electricity Maps."
+  title={`${SITE_AUTHOR} | About`}
+  description={`About ${SITE_AUTHOR}, Software Engineer based in Malmö, Sweden, working at Electricity Maps.`}
   canonicalURL={`${SITE_URL}/about`}
   structuredData={data.structuredData}
 />

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -2,6 +2,7 @@
   import TitleText from "$components/TitleText.svelte";
   import ProfileCard from "$components/ProfileCard.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
+  import { pageTitle } from "$lib/helpers/pageTitle";
   import { SITE_AUTHOR, SITE_URL } from "$lib/config";
   import type { PageData } from "./$types";
 
@@ -9,7 +10,7 @@
 </script>
 
 <SEO
-  title={`${SITE_AUTHOR} | About`}
+  title={pageTitle("About")}
   description={`About ${SITE_AUTHOR}, Software Engineer based in Malmö, Sweden, working at Electricity Maps.`}
   canonicalURL={`${SITE_URL}/about`}
   structuredData={data.structuredData}

--- a/apps/frontend/src/routes/activity/+page.svelte
+++ b/apps/frontend/src/routes/activity/+page.svelte
@@ -4,7 +4,8 @@
   import Highlight from "$components/Highlight.svelte";
   import TitleText from "$components/TitleText.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
-  import { SITE_AUTHOR, SITE_URL } from "$lib/config";
+  import { pageTitle } from "$lib/helpers/pageTitle";
+  import { SITE_URL } from "$lib/config";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -13,7 +14,7 @@
 </script>
 
 <SEO
-  title={`${SITE_AUTHOR} | Activity`}
+  title={pageTitle("Activity")}
   description={data.description}
   canonicalURL={`${SITE_URL}/activity`}
   structuredData={data.structuredData}

--- a/apps/frontend/src/routes/activity/+page.svelte
+++ b/apps/frontend/src/routes/activity/+page.svelte
@@ -4,7 +4,7 @@
   import Highlight from "$components/Highlight.svelte";
   import TitleText from "$components/TitleText.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
-  import { SITE_URL } from "$lib/config";
+  import { SITE_AUTHOR, SITE_URL } from "$lib/config";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -13,7 +13,7 @@
 </script>
 
 <SEO
-  title="Viktor Andersson | Activity"
+  title={`${SITE_AUTHOR} | Activity`}
   description={data.description}
   canonicalURL={`${SITE_URL}/activity`}
   structuredData={data.structuredData}

--- a/apps/frontend/src/routes/blog/+page.svelte
+++ b/apps/frontend/src/routes/blog/+page.svelte
@@ -3,13 +3,13 @@
   import SEO from "$lib/seo/components/SEO.svelte";
   import BlogPostList from "$components/blog/BlogPostList.svelte";
   import TitleText from "$components/TitleText.svelte";
-  import { SITE_AUTHOR } from "$lib/config";
+  import { pageTitle } from "$lib/helpers/pageTitle";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title={`${SITE_AUTHOR} | Blog${data.currentPage > 1 ? ` — Page ${data.currentPage}` : ""}`}
+  title={pageTitle(`Blog${data.currentPage > 1 ? ` — Page ${data.currentPage}` : ""}`)}
   description={data.description}
   canonicalURL={data.canonicalURL}
   prevURL={data.prevURL}

--- a/apps/frontend/src/routes/blog/+page.svelte
+++ b/apps/frontend/src/routes/blog/+page.svelte
@@ -3,12 +3,13 @@
   import SEO from "$lib/seo/components/SEO.svelte";
   import BlogPostList from "$components/blog/BlogPostList.svelte";
   import TitleText from "$components/TitleText.svelte";
+  import { SITE_AUTHOR } from "$lib/config";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title={`Viktor Andersson | Blog${data.currentPage > 1 ? ` — Page ${data.currentPage}` : ""}`}
+  title={`${SITE_AUTHOR} | Blog${data.currentPage > 1 ? ` — Page ${data.currentPage}` : ""}`}
   description={data.description}
   canonicalURL={data.canonicalURL}
   prevURL={data.prevURL}

--- a/apps/frontend/src/routes/blog/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { PageData } from './$types';
   import SEO from '$lib/seo/components/SEO.svelte';
-  import { SITE_URL } from '$lib/config';
+  import { SITE_AUTHOR, SITE_URL } from '$lib/config';
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import PostDate from '$components/blog/PostDate.svelte';
@@ -42,7 +42,7 @@
 {/snippet}
 
 <SEO
-  title={`${data.metadata.title} | Viktor Andersson`}
+  title={`${data.metadata.title} | ${SITE_AUTHOR}`}
   description={data.metadata.description}
   type="article"
   canonicalURL={data.postUrl}

--- a/apps/frontend/src/routes/blog/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { PageData } from './$types';
   import SEO from '$lib/seo/components/SEO.svelte';
-  import { SITE_AUTHOR, SITE_URL } from '$lib/config';
+  import { pageTitle } from '$lib/helpers/pageTitle';
+  import { SITE_URL } from '$lib/config';
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import PostDate from '$components/blog/PostDate.svelte';
@@ -42,7 +43,7 @@
 {/snippet}
 
 <SEO
-  title={`${data.metadata.title} | ${SITE_AUTHOR}`}
+  title={pageTitle(data.metadata.title)}
   description={data.metadata.description}
   type="article"
   canonicalURL={data.postUrl}

--- a/apps/frontend/src/routes/blog/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/page/[page]/+page.svelte
@@ -3,13 +3,13 @@
   import SEO from "$lib/seo/components/SEO.svelte";
   import BlogPostList from "$components/blog/BlogPostList.svelte";
   import TitleText from "$components/TitleText.svelte";
-  import { SITE_AUTHOR } from "$lib/config";
+  import { pageTitle } from "$lib/helpers/pageTitle";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title={`${SITE_AUTHOR} | Blog — Page ${data.currentPage}`}
+  title={pageTitle(`Blog — Page ${data.currentPage}`)}
   description={data.description}
   canonicalURL={data.canonicalURL}
   prevURL={data.prevURL}

--- a/apps/frontend/src/routes/blog/page/[page]/+page.svelte
+++ b/apps/frontend/src/routes/blog/page/[page]/+page.svelte
@@ -3,12 +3,13 @@
   import SEO from "$lib/seo/components/SEO.svelte";
   import BlogPostList from "$components/blog/BlogPostList.svelte";
   import TitleText from "$components/TitleText.svelte";
+  import { SITE_AUTHOR } from "$lib/config";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title={`Viktor Andersson | Blog — Page ${data.currentPage}`}
+  title={`${SITE_AUTHOR} | Blog — Page ${data.currentPage}`}
   description={data.description}
   canonicalURL={data.canonicalURL}
   prevURL={data.prevURL}

--- a/apps/frontend/src/routes/blog/tag/[tag]/listing.test.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/listing.test.ts
@@ -27,7 +27,7 @@ describe("loadTagListing", () => {
 
   it("titles page 1 without a page number and later pages with one", () => {
     const posts = postsTagged("vite", 1);
-    expect(loadTagListing("vite", 1, posts).title).toBe("Viktor Andersson | #vite");
-    expect(loadTagListing("vite", 2, posts).title).toBe("Viktor Andersson | #vite — Page 2");
+    expect(loadTagListing("vite", 1, posts).title).toBe("#vite | Viktor Andersson");
+    expect(loadTagListing("vite", 2, posts).title).toBe("#vite — Page 2 | Viktor Andersson");
   });
 });

--- a/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
@@ -1,7 +1,7 @@
 import type { BlogPostMeta } from "$lib/blog";
 
 import { getPostsForTag, isTagIndexable, paginatePosts, slugifyTag } from "$lib/blog";
-import { SITE_URL } from "$lib/config";
+import { SITE_AUTHOR, SITE_URL } from "$lib/config";
 import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
 import {
   createBreadcrumbListSchema,
@@ -55,7 +55,7 @@ export const loadTagListing = (tag: string, page: number, posts: BlogPostMeta[])
     ...paginated,
     tag: tagSlug,
     displayTag,
-    title: `Viktor Andersson | #${displayTag}${page > 1 ? ` — Page ${page}` : ""}`,
+    title: `${SITE_AUTHOR} | #${displayTag}${page > 1 ? ` — Page ${page}` : ""}`,
     robots,
     description,
     structuredData,

--- a/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
+++ b/apps/frontend/src/routes/blog/tag/[tag]/listing.ts
@@ -1,7 +1,8 @@
 import type { BlogPostMeta } from "$lib/blog";
 
 import { getPostsForTag, isTagIndexable, paginatePosts, slugifyTag } from "$lib/blog";
-import { SITE_AUTHOR, SITE_URL } from "$lib/config";
+import { SITE_URL } from "$lib/config";
+import { pageTitle } from "$lib/helpers/pageTitle";
 import { buildPaginationURLs } from "$lib/helpers/paginationURLs";
 import {
   createBreadcrumbListSchema,
@@ -55,7 +56,7 @@ export const loadTagListing = (tag: string, page: number, posts: BlogPostMeta[])
     ...paginated,
     tag: tagSlug,
     displayTag,
-    title: `${SITE_AUTHOR} | #${displayTag}${page > 1 ? ` — Page ${page}` : ""}`,
+    title: pageTitle(`#${displayTag}${page > 1 ? ` — Page ${page}` : ""}`),
     robots,
     description,
     structuredData,

--- a/apps/frontend/src/routes/history/+page.svelte
+++ b/apps/frontend/src/routes/history/+page.svelte
@@ -3,14 +3,14 @@
   import TitleText from "$components/TitleText.svelte";
   import { timelineEntries } from "$data/metadata";
   import SEO from "$lib/seo/components/SEO.svelte";
-  import { SITE_URL } from "$lib/config";
+  import { SITE_AUTHOR, SITE_URL } from "$lib/config";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title="Viktor Andersson | History"
+  title={`${SITE_AUTHOR} | History`}
   description={data.description}
   canonicalURL={`${SITE_URL}/history`}
   type="profile"

--- a/apps/frontend/src/routes/history/+page.svelte
+++ b/apps/frontend/src/routes/history/+page.svelte
@@ -3,14 +3,15 @@
   import TitleText from "$components/TitleText.svelte";
   import { timelineEntries } from "$data/metadata";
   import SEO from "$lib/seo/components/SEO.svelte";
-  import { SITE_AUTHOR, SITE_URL } from "$lib/config";
+  import { pageTitle } from "$lib/helpers/pageTitle";
+  import { SITE_URL } from "$lib/config";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
 </script>
 
 <SEO
-  title={`${SITE_AUTHOR} | History`}
+  title={pageTitle("History")}
   description={data.description}
   canonicalURL={`${SITE_URL}/history`}
   type="profile"

--- a/apps/frontend/src/routes/llms.txt/+server.ts
+++ b/apps/frontend/src/routes/llms.txt/+server.ts
@@ -1,6 +1,6 @@
 export const prerender = true;
 import { getAllPosts } from "$lib/blog.server";
-import { SITE_URL, SITE_DESCRIPTION } from "$lib/config";
+import { SITE_AUTHOR, SITE_URL, SITE_DESCRIPTION } from "$lib/config";
 import { SITE_PAGES, RESOURCE_LINKS, type SiteLink } from "$lib/pages";
 
 interface LlmsLink {
@@ -22,7 +22,7 @@ const _linkList = (links: LlmsLink[]): string =>
   links.map((link) => `- [${link.title}](${link.url}): ${link.description}`).join("\n");
 
 export const _buildLlmsTxt = (blogLinks: LlmsLink[]): string =>
-  `# Viktor Andersson
+  `# ${SITE_AUTHOR}
 
 > ${SITE_DESCRIPTION}
 

--- a/apps/frontend/src/routes/rss.xml/+server.ts
+++ b/apps/frontend/src/routes/rss.xml/+server.ts
@@ -1,6 +1,6 @@
 export const prerender = true;
 import { getAllPosts } from "$lib/blog.server";
-import { BLOG_DESCRIPTION, SITE_URL } from "$lib/config";
+import { BLOG_DESCRIPTION, SITE_AUTHOR, SITE_URL } from "$lib/config";
 
 interface RssItem {
   title: string;
@@ -10,7 +10,7 @@ interface RssItem {
 }
 
 export const _channel = {
-  title: "Viktor Andersson",
+  title: SITE_AUTHOR,
   link: `${SITE_URL}/blog`,
   description: BLOG_DESCRIPTION,
   feedURL: `${SITE_URL}/rss.xml`,

--- a/apps/frontend/src/tests/appHtml.test.ts
+++ b/apps/frontend/src/tests/appHtml.test.ts
@@ -1,4 +1,4 @@
-import { LICENSE_URL, SITE_URL } from "$lib/config";
+import { LICENSE_URL, SITE_AUTHOR, SITE_URL } from "$lib/config";
 import { describe, it, expect } from "bun:test";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +13,11 @@ describe("app.html", () => {
   it("declares the same license URL as LICENSE_URL", () => {
     const href = appHtml.match(/<link\s+rel="license"\s+href="([^"]+)"/)?.[1];
     expect(href).toBe(LICENSE_URL);
+  });
+
+  it("declares the same author as SITE_AUTHOR", () => {
+    const content = appHtml.match(/<meta\s+name="author"\s+content="([^"]+)"/)?.[1];
+    expect(content).toBe(SITE_AUTHOR);
   });
 
   it("hardcodes no other absolute URL to the site or repo", () => {


### PR DESCRIPTION
> **Stacked on #609** (which is stacked on #606). Review only this branch's two commits. Merge order: #606 → #609 → this.

## Problem

`"Viktor Andersson"` appeared **26 times across 18 files**, and the split forms `"Viktor"` / `"Andersson"` another four times in `person.ts` and `SEO.svelte`. Renaming meant finding all of them.

Page titles also used **three different shapes**, with the separator and ordering written out at eight call sites:

| shape | pages |
| --- | --- |
| `Name \| Section` | 6 |
| `Name - Software Engineer` | 1 (home, uses a dash) |
| `Post \| Name` | 1 (blog posts, name last) |

## Changes

**1. Single-source the name.** `SITE_AUTHOR` is composed from `AUTHOR_GIVEN_NAME` + `AUTHOR_FAMILY_NAME`, so the full and split forms cannot drift.

Two deliberate exclusions:
- **Test files keep literal expectations.** Importing the constant would make them tautological.
- **`app.html` cannot import** (static template), so its `<meta name="author">` is covered by a guard test asserting it matches `SITE_AUTHOR`.

**2. Name last in titles.** A `pageTitle` helper owns the separator and ordering. Sections now read `About | Viktor Andersson`.

The decisive argument is mechanical, not SEO: **browser tabs truncate from the right**, so name-first made every tab read `Viktor Anderss…` — indistinguishable across pages. Google's title guidance also asks that pages be distinguishable and warns against titles that vary by a single word. This makes the blog-post ordering the rule rather than an exception, which **collapsed what were two helpers into one**.

The **home page keeps the name first** — for a root page the site name *is* the distinctive content, and Google explicitly permits the name at the beginning or end.

## Titles after

```
About | Viktor Andersson
Blog | Viktor Andersson
History | Viktor Andersson
Hello World | Viktor Andersson
Viktor Andersson - Software Engineer      ← homepage, unchanged
```

## Verification

I confirmed the name refactor alone was **output-neutral** before flipping the titles: `sitemap.xml`, `rss.xml` and `llms.txt` byte-identical, and all HTML identical apart from asset content hashes.

svelte-check 0 errors / 0 warnings across 4277 files, 122 tests, oxfmt, oxlint, build clean.

## Note

This changes eight page titles — outward-facing. Expect brief search-result flux; the new format is the better one by Google's own guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)