### PR TITLE
frontend: Raise sub-AA text to the surface-300 tier

### DIFF
--- a/apps/frontend/src/components/ProfileCard.svelte
+++ b/apps/frontend/src/components/ProfileCard.svelte
@@ -16,7 +16,7 @@
   <div class="flex flex-col gap-0.5">
     <svelte:element this={as} class="text-2xl">Viktor Andersson</svelte:element>
     <p class="text-base text-surface-300">Software Engineer</p>
-    <p class="text-sm text-surface-400">Malmö, Sweden</p>
+    <p class="text-sm text-surface-300">Malmö, Sweden</p>
     <div class="flex flex-wrap gap-4 text-sm mt-1">
       <Link href="https://www.linkedin.com/in/viktor-va-andersson/" mono>open linkedin</Link>
       <Link href="https://github.com/viktorvav99" mono>open github</Link>

--- a/apps/frontend/src/routes/activity/+page.svelte
+++ b/apps/frontend/src/routes/activity/+page.svelte
@@ -27,9 +27,9 @@
     >
     <div class="flex flex-col gap-2">
       {#if activity === null}
-        <span class="text-surface-500">fatal: unable to read from remote</span>
+        <span class="text-surface-300">fatal: unable to read from remote</span>
       {:else if activity.log.length === 0}
-        <span class="text-surface-500">no recent activity</span>
+        <span class="text-surface-300">no recent activity</span>
       {:else}
         {#each activity.log as entry}
           <ActivityLine activity={entry} />


### PR DESCRIPTION
Lighthouse flagged the ProfileCard location line. Auditing every use of the two low tiers turned up a second, worse case it cannot see.

## Contrast on the `#111111` (surface-950) page background

| tier | hex | ratio | AA normal (4.5:1) | non-text (3:1) |
| --- | --- | --- | --- | --- |
| `surface-300` | `#adadad` | 8.41:1 | ✅ | ✅ |
| `surface-400` | `#707070` | 3.81:1 | ❌ | ✅ |
| `surface-500` | `#333333` | **1.49:1** | ❌ | ❌ |

## Fixed

| location | was | ratio |
| --- | --- | --- |
| `ProfileCard.svelte:19` — "Malmö, Sweden" | `surface-400` | 3.81:1 |
| `activity/+page.svelte:30` — `fatal: unable to read from remote` | `surface-500` | 1.49:1 |
| `activity/+page.svelte:32` — `no recent activity` | `surface-500` | 1.49:1 |

The `/activity` pair is the more serious of the two despite Lighthouse not reporting it: those spans only render when the GitHub request fails or returns nothing, i.e. exactly when a visitor needs to read them, so an automated pass over the happy path never sees them.

All three move to `surface-300`, already the tier used for muted body text elsewhere.

## Deliberately left alone

- **Timeline chevrons** (`TimelineAccordionCard.svelte:63-64`) — icons, so WCAG 1.4.11 applies at 3:1, which `surface-400` clears.
- **Homepage tree glyphs** (`+page.svelte:16`) — `aria-hidden` decoration, exempt from 1.4.3.

I verified this by classifying every remaining `text-surface-400/500` element in the built output: 9 `aria-hidden` glyphs and 12 icon SVGs, and **no visible text below AA**.

## Verification

svelte-check 0 errors / 0 warnings, 116 tests, build clean. Rendered output confirms `<p class="text-sm text-surface-300">Malmö, Sweden</p>`.

## Note on merge order

This is a pre-existing bug on `main`, independent of #605–#610. It touches `ProfileCard.svelte` line 19, adjacent to a line #610 edits, so whichever lands second may want a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)