### PR TITLE
frontend: Hyphenate blog slugs and 301 the legacy underscore URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ SvelteKit file-based routing with Svelte 5 runes (`$props()`, `$state()`, etc.).
 
 **Images/fonts:** `@sveltejs/enhanced-img` and `vite-imagetools` handle image processing (e.g. the OG image is an SVG rasterized to webp at build time); `fontaine` generates font fallback metrics.
 
-**Blog:** Markdown files in `src/blog_posts/` with YAML frontmatter (title, date, last_updated, description, tags). Processed by mdsvex with Shiki highlighting. Listing at `/blog`, posts at `/blog/[slug]` (slug = lowercased filename), tag pages at `/blog/tag/[tag]`.
+**Blog:** Markdown files in `src/blog_posts/` with YAML frontmatter (title, date, last_updated, description, tags, optional slug). Processed by mdsvex with Shiki highlighting. Listing at `/blog`, posts at `/blog/[slug]`, tag pages at `/blog/tag/[tag]`. The slug is the lowercased filename with underscores turned into hyphens, unless frontmatter `slug` overrides it; legacy underscore URLs 301 via `apps/frontend/_redirects`.
 
 **SEO:** Custom `SEO.svelte` component injects JSON-LD structured data, Open Graph tags, Twitter Card tags, canonical URLs, and robots meta into `<svelte:head>`. Schema types include Person, WebSite, BlogPosting, ProfilePage, CollectionPage, BreadcrumbList, and SoftwareSourceCode. `sitemap.xml` is a prerendered endpoint; `robots.txt` is a static asset.
 

--- a/apps/frontend/_redirects
+++ b/apps/frontend/_redirects
@@ -1,0 +1,4 @@
+# Legacy underscore blog URLs, kept alive after the switch to hyphenated slugs.
+/blog/hello_world /blog/hello-world 301
+/blog/website_stack /blog/website-stack 301
+/blog/flowtracing_go_brrrr /blog/dataflow-arm-axion-c4a 301

--- a/apps/frontend/src/blog_posts/Flowtracing_Go_Brrrr.md
+++ b/apps/frontend/src/blog_posts/Flowtracing_Go_Brrrr.md
@@ -1,5 +1,6 @@
 ---
 title: "Flowtracing Go Brrrr - Making our pipeline faster, cheaper and greener with ARM"
+slug: dataflow-arm-axion-c4a
 date: 2026-07-20
 last_updated: 2026-07-20
 description: "How we made the flowtracing pipeline at Electricity Maps 30% faster with 46% less CPU time by switching to Google's ARM-based Axion (C4A) processors on Dataflow, and what it actually took to get there."

--- a/apps/frontend/src/lib/blog.server.ts
+++ b/apps/frontend/src/lib/blog.server.ts
@@ -28,10 +28,16 @@ export const getAllPosts = (): BlogPostMeta[] => {
     const file = modules[path] as any;
     const metadata = file?.metadata as Record<string, any> | undefined;
     const raw = (rawPaths[path] as string) ?? "";
-    const slug = slugFromPath(path);
+    const moduleSlug = slugFromPath(path);
+    const slug = (metadata?.slug as string | undefined) ?? moduleSlug;
 
-    if (metadata && slug) {
-      posts.push({ ...metadata, slug, readingTime: calculateReadingTime(raw) } as BlogPostMeta);
+    if (metadata && slug && moduleSlug) {
+      posts.push({
+        ...metadata,
+        slug,
+        moduleSlug,
+        readingTime: calculateReadingTime(raw),
+      } as BlogPostMeta);
     }
   }
 

--- a/apps/frontend/src/lib/blog.test.ts
+++ b/apps/frontend/src/lib/blog.test.ts
@@ -1,7 +1,28 @@
-import { getAllTagSlugs, getPostsForTag, isTagIndexable, slugifyTag } from "$lib/blog";
+import {
+  getAllTagSlugs,
+  getPostsForTag,
+  isTagIndexable,
+  slugFromPath,
+  slugifyTag,
+} from "$lib/blog";
 import { describe, expect, it } from "bun:test";
 
 import { makePost, postsTagged } from "../tests/fixtures/posts";
+
+describe("slugFromPath", () => {
+  it("lowercases the filename and turns underscores into hyphens", () => {
+    expect(slugFromPath("/src/blog_posts/Hello_World.md")).toBe("hello-world");
+    expect(slugFromPath("/src/blog_posts/Flowtracing_Go_Brrrr.md")).toBe("flowtracing-go-brrrr");
+  });
+
+  it("leaves a filename without underscores alone beyond lowercasing", () => {
+    expect(slugFromPath("/src/blog_posts/Changelog.md")).toBe("changelog");
+  });
+
+  it("keeps existing hyphens", () => {
+    expect(slugFromPath("/src/blog_posts/Hello-World.md")).toBe("hello-world");
+  });
+});
 
 describe("slugifyTag", () => {
   it("lowercases and collapses non-alphanumeric runs", () => {

--- a/apps/frontend/src/lib/blog.ts
+++ b/apps/frontend/src/lib/blog.ts
@@ -7,6 +7,8 @@ export interface BlogPostMeta {
   last_updated?: string;
   tags?: string[];
   slug: string;
+  /** Slug derived from the filename, used to look the post's module up in the glob. */
+  moduleSlug?: string;
   readingTime: number;
 }
 
@@ -14,7 +16,7 @@ export interface BlogPostMeta {
 // an eager import.meta.glob here would pull every post into the client bundle. Post
 // loading lives in $lib/blog.server.ts (build-time) and $lib/blog-loader.ts (per-post).
 export const slugFromPath = (path: string): string | undefined =>
-  path.split("/").at(-1)?.replace(/\.md$/, "").toLowerCase();
+  path.split("/").at(-1)?.replace(/\.md$/, "").toLowerCase().replaceAll("_", "-");
 
 export const slugifyTag = (tag: string): string =>
   tag

--- a/apps/frontend/src/routes/blog/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/[slug]/+page.server.ts
@@ -33,6 +33,7 @@ export const load = async ({ params }: PageServerLoadEvent) => {
 
   return {
     slug: post.slug,
+    moduleSlug: post.moduleSlug,
     metadata: {
       title: post.title,
       description: post.description,

--- a/apps/frontend/src/routes/blog/[slug]/+page.ts
+++ b/apps/frontend/src/routes/blog/[slug]/+page.ts
@@ -3,7 +3,7 @@ import { getPostModule } from "$lib/blog-loader";
 import type { PageLoadEvent } from "./$types";
 
 export const load = async ({ data }: PageLoadEvent) => {
-  const file = await getPostModule(data.slug);
+  const file = await getPostModule(data.moduleSlug ?? data.slug);
   return {
     ...data,
     component: file.default,

--- a/apps/frontend/src/routes/sitemap.xml/+server.ts
+++ b/apps/frontend/src/routes/sitemap.xml/+server.ts
@@ -12,19 +12,26 @@ interface SitemapPage {
   path: string;
   priority: string;
   changefreq: string;
-  lastmod: string;
+  lastmod?: string;
 }
 
 const profileLastmod = PROFILE_DATE_MODIFIED.split("T")[0];
 
 const postLastmod = (post: BlogPostMeta): string => formatDate(post.last_updated || post.date);
 
-export const _staticPages: SitemapPage[] = SITE_PAGES.map((page) => ({
-  path: page.path,
-  priority: page.priority,
-  changefreq: page.changefreq,
-  lastmod: profileLastmod,
-}));
+// Pages whose content changes faster than the profile date can track. A hand-maintained
+// lastmod on those is worse than none at all.
+const LASTMOD_EXEMPT = new Set(["/activity"]);
+
+export const _staticPages: SitemapPage[] = SITE_PAGES.map((page) => {
+  const entry: SitemapPage = {
+    path: page.path,
+    priority: page.priority,
+    changefreq: page.changefreq,
+  };
+  if (!LASTMOD_EXEMPT.has(page.path)) entry.lastmod = profileLastmod;
+  return entry;
+});
 
 export const _tagSitemapPages = (posts: BlogPostMeta[]): SitemapPage[] =>
   getAllTagSlugs(posts).flatMap((tagSlug) => {
@@ -44,13 +51,15 @@ export const _buildSitemapXml = (pages: SitemapPage[]): string =>
   `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${pages
-  .map(
-    (page) => `  <url>
-    <loc>${SITE_URL}${page.path}</loc>
-    <lastmod>${page.lastmod}</lastmod>
-    <changefreq>${page.changefreq}</changefreq>
-    <priority>${page.priority}</priority>
-  </url>`,
+  .map((page) =>
+    [
+      "  <url>",
+      `    <loc>${SITE_URL}${page.path}</loc>`,
+      ...(page.lastmod ? [`    <lastmod>${page.lastmod}</lastmod>`] : []),
+      `    <changefreq>${page.changefreq}</changefreq>`,
+      `    <priority>${page.priority}</priority>`,
+      "  </url>",
+    ].join("\n"),
   )
   .join("\n")}
 </urlset>`;

--- a/apps/frontend/src/tests/llms.txt/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/llms.txt/__snapshots__/server.test.ts.snap
@@ -15,7 +15,7 @@ exports[`llms.txt should match snapshot 1`] = `
 
 ## Blog
 
-- [Hello World](https://viktor.andersson.tech/blog/hello_world): My first post
+- [Hello World](https://viktor.andersson.tech/blog/hello-world): My first post
 
 ## Optional
 

--- a/apps/frontend/src/tests/llms.txt/server.test.ts
+++ b/apps/frontend/src/tests/llms.txt/server.test.ts
@@ -6,7 +6,7 @@ import { _buildLlmsTxt, _sitePages, _optionalLinks } from "../../routes/llms.txt
 const testPosts = [
   {
     title: "Hello World",
-    url: "https://viktor.andersson.tech/blog/hello_world",
+    url: "https://viktor.andersson.tech/blog/hello-world",
     description: "My first post",
   },
 ];
@@ -32,7 +32,7 @@ describe("llms.txt", () => {
   it("should render links in `- [title](url): description` format", () => {
     const txt = _buildLlmsTxt(testPosts);
     expect(txt).toContain(
-      "- [Hello World](https://viktor.andersson.tech/blog/hello_world): My first post",
+      "- [Hello World](https://viktor.andersson.tech/blog/hello-world): My first post",
     );
     expect(txt).toContain(
       `- [${_sitePages[0].title}](${_sitePages[0].url}): ${_sitePages[0].description}`,

--- a/apps/frontend/src/tests/rss.xml/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/rss.xml/__snapshots__/server.test.ts.snap
@@ -12,8 +12,8 @@ exports[`rss.xml should match snapshot 1`] = `
     <atom:link href="https://viktor.andersson.tech/rss.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Hello &amp; &lt;World&gt;</title>
-      <link>https://viktor.andersson.tech/blog/hello_world</link>
-      <guid isPermaLink="true">https://viktor.andersson.tech/blog/hello_world</guid>
+      <link>https://viktor.andersson.tech/blog/hello-world</link>
+      <guid isPermaLink="true">https://viktor.andersson.tech/blog/hello-world</guid>
       <description>A &quot;quoted&quot; post</description>
       <pubDate>Fri, 20 Mar 2026 00:00:00 GMT</pubDate>
     </item>

--- a/apps/frontend/src/tests/rss.xml/server.test.ts
+++ b/apps/frontend/src/tests/rss.xml/server.test.ts
@@ -7,7 +7,7 @@ const pubDate = "Fri, 20 Mar 2026 00:00:00 GMT";
 const testItems = [
   {
     title: "Hello & <World>",
-    link: "https://viktor.andersson.tech/blog/hello_world",
+    link: "https://viktor.andersson.tech/blog/hello-world",
     description: 'A "quoted" post',
     pubDate,
   },
@@ -29,9 +29,9 @@ describe("rss.xml", () => {
 
   it("should include item link + permalink guid", () => {
     const xml = _buildRssXml(testItems, pubDate);
-    expect(xml).toContain("<link>https://viktor.andersson.tech/blog/hello_world</link>");
+    expect(xml).toContain("<link>https://viktor.andersson.tech/blog/hello-world</link>");
     expect(xml).toContain(
-      '<guid isPermaLink="true">https://viktor.andersson.tech/blog/hello_world</guid>',
+      '<guid isPermaLink="true">https://viktor.andersson.tech/blog/hello-world</guid>',
     );
   });
 

--- a/apps/frontend/src/tests/sitemap.xml/__snapshots__/server.test.ts.snap
+++ b/apps/frontend/src/tests/sitemap.xml/__snapshots__/server.test.ts.snap
@@ -17,7 +17,6 @@ exports[`sitemap.xml should match snapshot 1`] = `
   </url>
   <url>
     <loc>https://viktor.andersson.tech/activity</loc>
-    <lastmod>YYYY-MM-DD</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
@@ -34,7 +33,7 @@ exports[`sitemap.xml should match snapshot 1`] = `
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://viktor.andersson.tech/blog/hello_world</loc>
+    <loc>https://viktor.andersson.tech/blog/hello-world</loc>
     <lastmod>YYYY-MM-DD</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/apps/frontend/src/tests/sitemap.xml/server.test.ts
+++ b/apps/frontend/src/tests/sitemap.xml/server.test.ts
@@ -4,9 +4,11 @@ import { _buildSitemapXml, _staticPages } from "../../routes/sitemap.xml/+server
 
 const buildDate = "2026-03-20";
 
+// Only pages that already carry a lastmod get the fixed date — forcing one on would mask
+// the lastmod-less entries the sitemap deliberately emits.
 const testPages = [
-  ..._staticPages.map((p) => Object.assign({}, p, { lastmod: buildDate })),
-  { path: "/blog/hello_world", priority: "0.7", changefreq: "monthly", lastmod: buildDate },
+  ..._staticPages.map((p) => Object.assign({}, p, p.lastmod ? { lastmod: buildDate } : {})),
+  { path: "/blog/hello-world", priority: "0.7", changefreq: "monthly", lastmod: buildDate },
 ];
 
 describe("sitemap.xml", () => {
@@ -25,7 +27,19 @@ describe("sitemap.xml", () => {
 
   it("should include blog posts", () => {
     const xml = _buildSitemapXml(testPages);
-    expect(xml).toContain("<loc>https://viktor.andersson.tech/blog/hello_world</loc>");
+    expect(xml).toContain("<loc>https://viktor.andersson.tech/blog/hello-world</loc>");
+  });
+
+  it("should leave /activity without a lastmod", () => {
+    const activity = _staticPages.find((p) => p.path === "/activity");
+    expect(activity).toBeDefined();
+    expect(activity?.lastmod).toBeUndefined();
+  });
+
+  it("should omit the lastmod element for pages without one", () => {
+    const xml = _buildSitemapXml([{ path: "/activity", priority: "0.7", changefreq: "daily" }]);
+    expect(xml).toContain("<loc>https://viktor.andersson.tech/activity</loc>");
+    expect(xml).not.toContain("<lastmod>");
   });
 
   it("should include domain", () => {


### PR DESCRIPTION
Follow-up from an external SEO review: underscores are word-joiners to Google, hyphens are separators.

- `slugFromPath` now folds underscores to hyphens, so slugs become `/blog/hello-world`, `/blog/website-stack`, etc.
- New optional frontmatter `slug` override; the flowtracing post uses it to get the keyword slug `/blog/dataflow-arm-axion-c4a`. The module lookup keeps working via a `moduleSlug` passed through the post load.
- New `apps/frontend/_redirects` (Workers static assets, applied before the Worker runs) 301s the three published legacy URLs.
- Sitemap `lastmod` is now optional and no longer emitted for `/activity` — its content refreshes hourly and the hand-edited profile date was wrong for it; `/about` and `/history` keep `PROFILE_DATE_MODIFIED`.

Known trade-off: RSS guids are the post URLs, so readers will re-show the three posts as unread once.

## Test plan
- `bun test`: 127 pass, snapshot diffs are exactly the slug renames + the removed `/activity` lastmod.
- `bun run build`: hyphenated post pages emitted, no underscore HTML, `_redirects` lands in `.svelte-kit/cloudflare/` with the 3 rules.
- Post-deploy: `curl -I` the three old URLs → expect 301 with the new location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)