### PR TITLE
frontend: Split SERP titles from social titles and enrich article metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ SvelteKit file-based routing with Svelte 5 runes (`$props()`, `$state()`, etc.).
 
 **Images/fonts:** `@sveltejs/enhanced-img` and `vite-imagetools` handle image processing (e.g. the OG image is an SVG rasterized to webp at build time); `fontaine` generates font fallback metrics.
 
-**Blog:** Markdown files in `src/blog_posts/` with YAML frontmatter (title, date, last_updated, description, tags, optional slug). Processed by mdsvex with Shiki highlighting. Listing at `/blog`, posts at `/blog/[slug]`, tag pages at `/blog/tag/[tag]`. The slug is the lowercased filename with underscores turned into hyphens, unless frontmatter `slug` overrides it; legacy underscore URLs 301 via `apps/frontend/_redirects`.
+**Blog:** Markdown files in `src/blog_posts/` with YAML frontmatter (title, date, last_updated, description, tags, optional slug, seo_title, image, image_alt). Processed by mdsvex with Shiki highlighting. Listing at `/blog`, posts at `/blog/[slug]`, tag pages at `/blog/tag/[tag]`. The slug is the lowercased filename with underscores turned into hyphens, unless frontmatter `slug` overrides it; legacy underscore URLs 301 via `apps/frontend/_redirects`.
 
 **SEO:** Custom `SEO.svelte` component injects JSON-LD structured data, Open Graph tags, Twitter Card tags, canonical URLs, and robots meta into `<svelte:head>`. Schema types include Person, WebSite, BlogPosting, ProfilePage, CollectionPage, BreadcrumbList, and SoftwareSourceCode. `sitemap.xml` is a prerendered endpoint; `robots.txt` is a static asset.
 

--- a/apps/frontend/src/blog_posts/Flowtracing_Go_Brrrr.md
+++ b/apps/frontend/src/blog_posts/Flowtracing_Go_Brrrr.md
@@ -1,5 +1,6 @@
 ---
 title: "Flowtracing Go Brrrr - Making our pipeline faster, cheaper and greener with ARM"
+seo_title: "Apache Beam on Arm: Moving Dataflow to Google Axion C4A"
 slug: dataflow-arm-axion-c4a
 date: 2026-07-20
 last_updated: 2026-07-20

--- a/apps/frontend/src/components/Footer.svelte
+++ b/apps/frontend/src/components/Footer.svelte
@@ -22,7 +22,7 @@
       <ul class="flex flex-wrap gap-x-6 gap-y-1">
         {#each SOCIAL_LINKS as social}
           <li>
-            <Link href={social.href} class="text-surface-100">{social.label}</Link>
+            <Link href={social.href} rel={social.rel} class="text-surface-100">{social.label}</Link>
           </li>
         {/each}
       </ul>

--- a/apps/frontend/src/components/ProfileCard.svelte
+++ b/apps/frontend/src/components/ProfileCard.svelte
@@ -20,7 +20,7 @@
     <p class="text-sm text-surface-300">Malmö, Sweden</p>
     <div class="flex flex-wrap gap-4 text-sm mt-1">
       {#each SOCIAL_LINKS as social}
-        <Link href={social.href} mono>{social.label}</Link>
+        <Link href={social.href} rel={social.rel} mono>{social.label}</Link>
       {/each}
     </div>
   </div>

--- a/apps/frontend/src/lib/blog.server.ts
+++ b/apps/frontend/src/lib/blog.server.ts
@@ -4,10 +4,10 @@ import { slugFromPath } from "$lib/blog";
 
 const WORDS_PER_MINUTE = 200;
 
-const calculateReadingTime = (raw: string): number => {
+/** Words in the post body, frontmatter stripped. */
+const countWords = (raw: string): number => {
   const body = raw.replace(/^---[\s\S]*?---/, "").trim();
-  const words = body.match(/\S+/g)?.length ?? 0;
-  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+  return body.match(/\S+/g)?.length ?? 0;
 };
 
 /**
@@ -32,11 +32,14 @@ export const getAllPosts = (): BlogPostMeta[] => {
     const slug = (metadata?.slug as string | undefined) ?? moduleSlug;
 
     if (metadata && slug && moduleSlug) {
+      const wordCount = countWords(raw);
+
       posts.push({
         ...metadata,
         slug,
         moduleSlug,
-        readingTime: calculateReadingTime(raw),
+        readingTime: Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE)),
+        wordCount,
       } as BlogPostMeta);
     }
   }

--- a/apps/frontend/src/lib/blog.ts
+++ b/apps/frontend/src/lib/blog.ts
@@ -9,7 +9,13 @@ export interface BlogPostMeta {
   slug: string;
   /** Slug derived from the filename, used to look the post's module up in the glob. */
   moduleSlug?: string;
+  /** Overrides the `<title>` tag; the `title` still drives the heading and social cards. */
+  seo_title?: string;
+  /** Social card image, absolute or site-root relative. Falls back to the hero banner. */
+  image?: string;
+  image_alt?: string;
   readingTime: number;
+  wordCount: number;
 }
 
 // Glob-free by design: the client reaches this module for slugFromPath/slugifyTag, so

--- a/apps/frontend/src/lib/config.ts
+++ b/apps/frontend/src/lib/config.ts
@@ -22,9 +22,9 @@ export const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
  * Labels are the link text everywhere, so the same destination reads the same in both places.
  */
 export const SOCIAL_LINKS = [
-  { label: "github", href: "https://github.com/viktorvav99" },
-  { label: "linkedin", href: "https://www.linkedin.com/in/viktor-va-andersson/" },
-  { label: "bluesky", href: "https://bsky.app/profile/viktor.andersson.tech" },
+  { label: "github", href: "https://github.com/viktorvav99", rel: "me" },
+  { label: "linkedin", href: "https://www.linkedin.com/in/viktor-va-andersson/", rel: "me" },
+  { label: "bluesky", href: "https://bsky.app/profile/viktor.andersson.tech", rel: "me" },
 ] as const;
 
 /** Identity URLs added to the Person schema's sameAs only, never rendered as links. */
@@ -32,6 +32,9 @@ export const IDENTITY_URLS: readonly string[] = [
   "https://dev.to/viktorvav99",
   "https://x.com/VIKTORVAV99",
 ];
+
+/** Matches the x.com entry in IDENTITY_URLS; emitted as twitter:site and twitter:creator. */
+export const TWITTER_HANDLE = "@VIKTORVAV99";
 
 // Social scrapers (Open Graph, Twitter Cards) and Google's structured-data
 // parser require absolute image URLs, so prefix the Vite asset path.

--- a/apps/frontend/src/lib/helpers/pageTitle.test.ts
+++ b/apps/frontend/src/lib/helpers/pageTitle.test.ts
@@ -15,4 +15,20 @@ describe("pageTitle", () => {
   it("reads the same for a post title as for a section", () => {
     expect(pageTitle("A post about Svelte")).toBe("A post about Svelte | Viktor Andersson");
   });
+
+  it("keeps the suffix when the full title lands on 60 chars", () => {
+    const section = "s".repeat(41);
+    expect(pageTitle(section)).toBe(`${section} | ${SITE_AUTHOR}`);
+    expect(pageTitle(section)).toHaveLength(60);
+  });
+
+  it("drops the suffix when the full title would pass 60 chars", () => {
+    const section = "s".repeat(42);
+    expect(pageTitle(section)).toBe(section);
+  });
+
+  it("returns a long post title unchanged", () => {
+    const title = "Flowtracing Go Brrrr - Making our pipeline faster, cheaper and greener with ARM";
+    expect(pageTitle(title)).toBe(title);
+  });
 });

--- a/apps/frontend/src/lib/helpers/pageTitle.ts
+++ b/apps/frontend/src/lib/helpers/pageTitle.ts
@@ -1,5 +1,11 @@
 import { SITE_AUTHOR } from "$lib/config";
 
-/** `<section> | <author>`; the bare author when no section is given. */
-export const pageTitle = (section?: string) =>
-  section ? `${section} | ${SITE_AUTHOR}` : SITE_AUTHOR;
+/** Maximum `<title>` length before the author suffix is dropped. */
+const MAX_TITLE_LENGTH = 60;
+
+/** `<section> | <author>`, or the bare section past 60 chars; the bare author when no section is given. */
+export const pageTitle = (section?: string) => {
+  if (!section) return SITE_AUTHOR;
+  const withAuthor = `${section} | ${SITE_AUTHOR}`;
+  return withAuthor.length <= MAX_TITLE_LENGTH ? withAuthor : section;
+};

--- a/apps/frontend/src/lib/seo/components/SEO.svelte
+++ b/apps/frontend/src/lib/seo/components/SEO.svelte
@@ -8,12 +8,14 @@
     AUTHOR_FAMILY_NAME,
     AUTHOR_GIVEN_NAME,
     SITE_AUTHOR,
+    TWITTER_HANDLE,
   } from "$lib/config";
   import type { Robots, StructuredDataSchema } from "..";
   import { ROBOTS, toJsonLd } from "..";
 
   let {
     title,
+    socialTitle = title,
     description,
     canonicalURL,
     prevURL,
@@ -21,15 +23,18 @@
     structuredData,
     robots = ROBOTS.default,
     image = FALLBACK_HERO_IMAGE,
-    imageWidth = FALLBACK_HERO_IMAGE_WIDTH,
-    imageHeight = FALLBACK_HERO_IMAGE_HEIGHT,
-    imageAlt = "viktor.andersson.tech",
+    imageWidth,
+    imageHeight,
+    imageAlt = `Hero banner for ${SITE_AUTHOR}'s personal website`,
+    imageType,
     type = "website",
     publishedTime,
     modifiedTime,
     tags,
   }: {
     title: string;
+    /** og:title and twitter:title; defaults to the `<title>`. */
+    socialTitle?: string;
     description: string;
     canonicalURL?: string;
     prevURL?: string;
@@ -40,6 +45,8 @@
     imageWidth?: number;
     imageHeight?: number;
     imageAlt?: string;
+    /** MIME type of `image`; sniffed from its extension when omitted. */
+    imageType?: string;
     type?: "website" | "article" | "profile" | string;
     /** ISO 8601 date; emitted as article:published_time when type is "article" */
     publishedTime?: string;
@@ -53,6 +60,30 @@
   const resolvedCanonicalURL = $derived(
     canonicalURL ??
       (robots.startsWith("noindex") ? undefined : SITE_URL + page.url.pathname.replace(/\/$/, "")),
+  );
+
+  const IMAGE_TYPES: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    webp: "image/webp",
+    gif: "image/gif",
+  };
+
+  const resolvedImageType = $derived.by(() => {
+    if (imageType) return imageType;
+    const extension = image?.split("?")[0].split(".").at(-1)?.toLowerCase();
+    return extension ? IMAGE_TYPES[extension] : undefined;
+  });
+
+  // Dimensions describe the fallback banner only; a custom image without explicit
+  // dims gets no og:image:width/height.
+  const isFallbackImage = $derived(image === FALLBACK_HERO_IMAGE);
+  const resolvedImageWidth = $derived(
+    imageWidth ?? (isFallbackImage ? FALLBACK_HERO_IMAGE_WIDTH : undefined),
+  );
+  const resolvedImageHeight = $derived(
+    imageHeight ?? (isFallbackImage ? FALLBACK_HERO_IMAGE_HEIGHT : undefined),
   );
 </script>
 
@@ -74,7 +105,7 @@
   <meta property="og:site_name" content={SITE_AUTHOR} />
   <meta property="og:locale" content="en_US" />
   <meta property="og:type" content={type} />
-  <meta property="og:title" content={title} />
+  <meta property="og:title" content={socialTitle} />
   <meta property="og:description" content={description} />
 
   {#if type === "article"}
@@ -94,14 +125,21 @@
     <meta name="twitter:image" content={image} />
     <meta name="twitter:image:alt" content={imageAlt} />
     <meta property="og:image" content={image} />
-    <meta property="og:image:width" content={String(imageWidth)} />
-    <meta property="og:image:height" content={String(imageHeight)} />
+    {#if resolvedImageType}<meta property="og:image:type" content={resolvedImageType} />{/if}
+    {#if resolvedImageWidth}
+      <meta property="og:image:width" content={String(resolvedImageWidth)} />
+    {/if}
+    {#if resolvedImageHeight}
+      <meta property="og:image:height" content={String(resolvedImageHeight)} />
+    {/if}
     <meta property="og:image:alt" content={imageAlt} />
   {:else}
     <meta name="twitter:card" content="summary" />
   {/if}
 
-  <meta name="twitter:title" content={title} />
+  <meta name="twitter:title" content={socialTitle} />
+  <meta name="twitter:site" content={TWITTER_HANDLE} />
+  <meta name="twitter:creator" content={TWITTER_HANDLE} />
   <meta name="twitter:description" content={description} />
 
   <meta name="robots" content={robots} />

--- a/apps/frontend/src/lib/seo/index.ts
+++ b/apps/frontend/src/lib/seo/index.ts
@@ -212,6 +212,8 @@ export interface ArticleSchema {
   mainEntityOfPage?: WebPageSchema | string;
   isPartOf?: NodeRefSchema;
   wordCount?: number;
+  /** ISO 8601 duration, e.g. "PT7M". */
+  timeRequired?: string;
   keywords?: string | string[];
   articleBody?: string;
   url?: string;

--- a/apps/frontend/src/routes/blog/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/blog/[slug]/+page.server.ts
@@ -31,17 +31,26 @@ export const load = async ({ params }: PageServerLoadEvent) => {
       ? { slug: posts[index + 1].slug, title: posts[index + 1].title }
       : undefined;
 
+  const image = post.image
+    ? post.image.startsWith("http")
+      ? post.image
+      : `${SITE_URL}${post.image}`
+    : FALLBACK_HERO_IMAGE;
+
   return {
     slug: post.slug,
     moduleSlug: post.moduleSlug,
     metadata: {
       title: post.title,
+      seo_title: post.seo_title,
       description: post.description,
       date: post.date,
       last_updated: post.last_updated,
       tags: post.tags,
     },
     readingTime: post.readingTime,
+    image,
+    imageAlt: post.image_alt,
     postUrl,
     datePublished,
     dateModified,
@@ -57,7 +66,9 @@ export const load = async ({ params }: PageServerLoadEvent) => {
         url: postUrl,
         mainEntityOfPage: createWebPageSchema({ "@id": postUrl }),
         isPartOf: SITE_WEBSITE_REF,
-        image: FALLBACK_HERO_IMAGE,
+        image,
+        wordCount: post.wordCount,
+        timeRequired: `PT${post.readingTime}M`,
       }),
       createBreadcrumbListSchema([
         { name: "Home", url: SITE_URL },

--- a/apps/frontend/src/routes/blog/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/blog/[slug]/+page.svelte
@@ -43,7 +43,8 @@
 {/snippet}
 
 <SEO
-  title={pageTitle(data.metadata.title)}
+  title={pageTitle(data.metadata.seo_title ?? data.metadata.title)}
+  socialTitle={data.metadata.title}
   description={data.metadata.description}
   type="article"
   canonicalURL={data.postUrl}
@@ -53,6 +54,8 @@
   publishedTime={data.datePublished}
   modifiedTime={data.dateModified}
   tags={data.metadata.tags}
+  image={data.image}
+  imageAlt={data.imageAlt}
 />
 
 <article class="w-full max-w-prose mx-auto mt-16 flex flex-1 flex-col gap-8">

--- a/apps/frontend/src/tests/fixtures/posts.ts
+++ b/apps/frontend/src/tests/fixtures/posts.ts
@@ -5,6 +5,7 @@ export const makePost = (overrides: Partial<BlogPostMeta> & { slug: string }): B
   description: overrides.slug,
   date: "2026-01-01",
   readingTime: 1,
+  wordCount: 200,
   ...overrides,
 });
 


### PR DESCRIPTION
> **Stacked on #612** — merge that first. If it gets squash-merged, rebase this branch onto main before merging.

Follow-up from an external SEO review: long post titles were spending ~19 chars of SERP width on the `| Viktor Andersson` suffix, and the flowtracing post's title had no searchable keywords.

- `pageTitle()` drops the author suffix when the combined title exceeds 60 chars; short pages (About, Blog, tags) are unchanged.
- New optional `seo_title` frontmatter drives the `<title>` tag; `og:title`/`twitter:title` keep the display title via a new `socialTitle` prop. The flowtracing post serves `Apache Beam on Arm: Moving Dataflow to Google Axion C4A` to crawlers while the page keeps its playful H1.
- Image block: `og:image:type` (extension-sniffed — the fallback emits `.jpeg`), width/height now only asserted for the fallback image, descriptive `og:image:alt`, and frontmatter `image`/`image_alt` plumbing for future posts.
- `twitter:site`/`twitter:creator` (@VIKTORVAV99) and `rel="me"` on the social links.
- Article JSON-LD gains `wordCount` and `timeRequired` (`PT9M` for flowtracing), computed from the existing reading-time word count.

## Test plan
- `bun test`: 130 pass (3 new pageTitle boundary tests).
- `bun run build`: flowtracing HTML has the keyword `<title>`, playful `og:title`, `og:image:type=image/jpeg`, `twitter:creator`, and `"wordCount":1713`/`"timeRequired":"PT9M"` in JSON-LD; `/about` keeps `About | Viktor Andersson` and its social links render `rel="noopener noreferrer me"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)