### PR TITLE
frontend: Add internal links and title anchor text on the homepage tree

### DIFF
--- a/apps/frontend/src/blog_posts/Hello_World.md
+++ b/apps/frontend/src/blog_posts/Hello_World.md
@@ -8,4 +8,4 @@ tags: ["SvelteKit", "MDsveX", "Blog"]
 
 Yes it's a bit cliché with a Hello World post but at this point it's almost tradition!
 
-In the coming posts I'll be digging into the technical details of this website. Including framework and platform choices, optimizations and performance improvements, SEO and structured data. I'll also be sharing technical deep dives into some of the projects I've worked on professionally and personally, and maybe some thoughts on the industry and software engineering in general.
+In the coming posts I'll be digging into the technical details of this website. Including [framework and platform choices](/blog/website-stack), optimizations and performance improvements, SEO and structured data. I'll also be sharing technical deep dives into some of the projects I've worked on professionally and personally, and maybe some thoughts on the industry and software engineering in general.

--- a/apps/frontend/src/blog_posts/Website_Stack.md
+++ b/apps/frontend/src/blog_posts/Website_Stack.md
@@ -12,7 +12,7 @@ tags: ["SvelteKit", "MDsveX", "TailwindCSS", "Cloudflare", "Vite"]
 
 ### Framework: Svelte and SvelteKit
 
-I've tried both Angular and React extensively before, but Angular felt a bit heavy for the task and React just isn't opinionated enough (no batteries included). So, it was time for something new. I made this choice years ago but didn't build a blog before. After my website revamp a week or so ago I decided it was time to make a blog post about it.
+I've tried both Angular and React extensively before, but Angular felt a bit heavy for the task and React just isn't opinionated enough (no batteries included). So, it was time for something new. I made this choice years ago but didn't build a blog before. After my [website revamp](/blog/hello-world) a week or so ago I decided it was time to make a blog post about it.
 
 So I picked Svelte, or more accurately SvelteKit, the meta framework around Svelte that comes with all the features I need. Vue was also in the running but Svelte's syntax and SvelteKit's features won me over. It was as similar to pure HTML and JS I could find at the time and the fact that SvelteKit compiles all the code means it sends less code to the browser which is just a win for everyone involved.
 

--- a/apps/frontend/src/routes/+page.server.ts
+++ b/apps/frontend/src/routes/+page.server.ts
@@ -29,11 +29,11 @@ const structuredData = [
   }),
 ];
 
-const blogSlugs = getAllPosts()
+const blogPosts = getAllPosts()
   .slice(0, 5)
-  .map((post) => post.slug);
+  .map((post) => ({ slug: post.slug, title: post.title }));
 
 export const load = (() => ({
   structuredData,
-  blogSlugs,
+  blogPosts,
 })) satisfies PageServerLoad;

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -9,12 +9,12 @@
 
   let { data }: { data: PageData } = $props();
 
-  const blogSlugs = $derived(data.blogSlugs);
+  const blogPosts = $derived(data.blogPosts);
   const treePages = SITE_PAGES.filter((page) => page.path !== "" && page.path !== "/blog");
 </script>
 
 {#snippet treeChar(char: string)}<span class="text-2xl text-surface-500" aria-hidden="true">{char}</span>{/snippet}
-{#snippet treeLink(href: string, label: string, prefix: string)}<a {href} class="flex items-center link-plain">{@render treeChar(prefix)}<span class="hover:underline underline-offset-4">{label}</span></a>{/snippet}
+{#snippet treeLink(href: string, label: string, prefix: string)}<a {href} class="flex items-baseline link-plain">{@render treeChar(prefix)}<span class="hover:underline underline-offset-4 whitespace-normal">{label}</span></a>{/snippet}
 
 <SEO
   title={`${SITE_AUTHOR} - Software Engineer`}
@@ -30,8 +30,8 @@
       {@render treeLink(page.path, page.path.slice(1), "├── ")}
     {/each}
     {@render treeLink("/blog", "blog/", "└─┬ ")}
-    {#each blogSlugs as slug}
-      {@render treeLink(`/blog/${slug}`, slug, "  ├── ")}
+    {#each blogPosts as post}
+      {@render treeLink(`/blog/${post.slug}`, post.title, "  ├── ")}
     {/each}
     {@render treeLink("/blog", "...", "  └── ")}
   </nav>

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import TitleText from "$components/TitleText.svelte";
   import ProfileCard from "$components/ProfileCard.svelte";
+  import Link from "$components/Link.svelte";
   import SEO from "$lib/seo/components/SEO.svelte";
   import { pageTitle } from "$lib/helpers/pageTitle";
   import { SITE_AUTHOR, SITE_URL } from "$lib/config";
@@ -33,7 +34,7 @@
     <section class="flex flex-col gap-4">
       <h2>Professional</h2>
       <p class="text-surface-300 text-base">
-        I work as a full-stack Software Engineer at Electricity Maps and work on everything from our data ingestion, processing pipelines and optimizing our frontend application (optimizations I do for fun).
+        I work as a full-stack Software Engineer at <Link href="https://www.electricitymaps.com">Electricity Maps</Link> and work on everything from our data ingestion, <Link href="/blog/dataflow-arm-axion-c4a">processing pipelines</Link> and optimizing our frontend application (optimizations I do for fun).
         I have a passion for optimization, performance and automating things as much as possible.
         I prefer to do this in a way that is maintainable and lowers our technical debt, processing needs and data usage so it has as low impact on the environment as possible.
         Plus making things faster is just fun and provides a better user experience for our users, both internal and external.


### PR DESCRIPTION
> **Stacked on #612** — merge that first. If it gets squash-merged, rebase this branch onto main before merging.

Follow-up from an external SEO review: zero in-body internal links existed anywhere, and the homepage tree linked posts by raw slug.

- The homepage tree now uses full post titles as anchor text (`+page.server.ts` returns `{slug, title}` pairs); labels wrap under the tree prefix on narrow screens via `items-baseline` + `whitespace-normal`.
- First in-body internal links, wrapping existing words only: Hello World → Website Stack, Website Stack → Hello World, and `/about` links the flowtracing post ("processing pipelines") plus electricitymaps.com.

## Test plan
- `bun run build`: prerender crawl passes; built homepage shows titles as link text; `/about`'s internal links render icon-free while the electricitymaps.com link keeps the external treatment.
- `bun test`: 127 pass.
- Worth a quick visual check of the homepage tree at mobile width — long titles wrap, label text sits ~2px lower than before within the same row height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)