### PR TITLE
frontend: Draw the homepage tree rails with CSS instead of glyphs

### DIFF
--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -13,8 +13,10 @@
   const treePages = SITE_PAGES.filter((page) => page.path !== "" && page.path !== "/blog");
 </script>
 
-{#snippet treeChar(char: string)}<span class="text-2xl text-surface-500" aria-hidden="true">{char}</span>{/snippet}
-{#snippet treeLink(href: string, label: string, prefix: string)}<a {href} class="flex items-baseline link-plain">{@render treeChar(prefix)}<span class="hover:underline underline-offset-4 whitespace-normal">{label}</span></a>{/snippet}
+{#snippet treeLink(href: string, label: string)}<a
+    {href}
+    class="link-plain hover:underline underline-offset-4">{label}</a
+  >{/snippet}
 
 <SEO
   title={`${SITE_AUTHOR} - Software Engineer`}
@@ -24,15 +26,76 @@
 <div class="page-container">
   <TitleText path="" subtitle="Welcome" />
   <ProfileCard as="h1" />
-  <nav aria-label="Site map" class="font-mono text-lg flex flex-col w-full leading-tight whitespace-pre">
+  <nav aria-label="Site map" class="font-mono text-lg leading-tight w-full">
     <span><Highlight>~</Highlight>/</span>
-    {#each treePages as page}
-      {@render treeLink(page.path, page.path.slice(1), "├── ")}
-    {/each}
-    {@render treeLink("/blog", "blog/", "└─┬ ")}
-    {#each blogPosts as post}
-      {@render treeLink(`/blog/${post.slug}`, post.title, "  ├── ")}
-    {/each}
-    {@render treeLink("/blog", "...", "  └── ")}
+    <ul class="tree">
+      {#each treePages as page}
+        <li>{@render treeLink(page.path, page.path.slice(1))}</li>
+      {/each}
+      <li>
+        {@render treeLink("/blog", "blog/")}
+        <ul class="tree">
+          {#each blogPosts as post}
+            <li>{@render treeLink(`/blog/${post.slug}`, post.title)}</li>
+          {/each}
+          <li>{@render treeLink("/blog", "...")}</li>
+        </ul>
+      </li>
+    </ul>
   </nav>
 </div>
+
+<style>
+  /* The connectors are drawn with borders instead of box-drawing glyphs so the
+     rails span a row's full height and stay attached when a title wraps. */
+  .tree {
+    --rail-color: var(--color-surface-500);
+    --rail-width: 1.5px;
+    /* Row padding plus half the leading-tight line box: the first line's center. */
+    --rail-tick-y: calc(0.2em + 0.625em);
+    /* Vertical distance from a row's tick down to a nested list's top edge. */
+    --rail-join: 0.625em;
+  }
+
+  .tree li {
+    position: relative;
+    padding-block: 0.2em;
+    padding-left: 4ch;
+  }
+
+  /* ├── the horizontal tick from the rail to the label. */
+  .tree li::before {
+    content: "";
+    position: absolute;
+    top: var(--rail-tick-y);
+    left: 0;
+    width: 3ch;
+    border-top: var(--rail-width) solid var(--rail-color);
+  }
+
+  /* │ the vertical rail, spanning the full row. */
+  .tree li::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-left: var(--rail-width) solid var(--rail-color);
+  }
+
+  /* └ the last row's rail stops at its tick. */
+  .tree li:last-child::after {
+    height: var(--rail-tick-y);
+  }
+
+  /* ┬ nested lists start one step in, and the first row's rail reaches back up
+     to the parent row's tick. */
+  .tree .tree {
+    margin-left: -1ch;
+  }
+
+  .tree .tree > li:first-child::after {
+    top: calc(-1 * var(--rail-join));
+    height: calc(100% + var(--rail-join));
+  }
+</style>


### PR DESCRIPTION
Follow-up to #615: the glyph-based tree connectors broke once post titles could wrap — a `├` is exactly one line box tall, so a two-line title left a hole in the rail, and the baseline alignment opened hairline gaps between every row.

The tree is now a semantic nested `<ul>` and the connectors are drawn with CSS borders on `::before`/`::after` (same idea as an SVG rendering, but the rails size themselves to each row, so no geometry to precompute). Ticks sit at the first line's center, the last row's rail stops at its tick (`└`), and a nested list's first rail reaches up to meet the parent tick (`┬`). The decorative glyph spans (and their `aria-hidden`) are gone entirely.

Verified with Playwright screenshots at 1280px and 375px: rails stay attached through 2- and 4-line wrapped titles.

## Test plan
- `bun test`: 130 pass; `svelte-check`: 0 errors; oxlint clean.
- `bun run build` + screenshot of the built homepage at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)